### PR TITLE
chore: ingest SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,31 @@
+# general
+# sort in alphabetical order
+disabled_rules:
+  - force_cast
+  - nesting
+  - no_fallthrough_only
+  - trailing_comma
+
+opt_in_rules:
+  - sorted_imports
+
+# configurable rules
+# sort in alphabetical order
+cyclomatic_complexity: 14
+
+file_length:
+  warning: 800
+  error: 1500
+
+identifier_name:
+  min_length: 2
+  max_length: 40
+  allowed_symbols: ["_"]
+
+line_length: 250
+
+type_name:
+  min_length: 2
+  max_length: 40
+  allowed_symbols: ["_"]
+

--- a/ListKit.xcodeproj/project.pbxproj
+++ b/ListKit.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 			buildPhases = (
 				OBJ_17 /* Sources */,
 				OBJ_19 /* Frameworks */,
+				F8FD93942877197B00DFF7DA /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -680,6 +681,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		F8FD93942877197B00DFF7DA /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $(uname -p) == 'arm' ]]; then\n  # add M1 homebrew path\n  export PATH=\"$PATH:/opt/homebrew/bin\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		F36550132451B4050038172F /* Sources */ = {

--- a/ListKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ListKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ListKitExample/ListKit.playground/Contents.swift
+++ b/ListKitExample/ListKit.playground/Contents.swift
@@ -1,6 +1,6 @@
-import UIKit
-import PlaygroundSupport
 import ListKit
+import PlaygroundSupport
+import UIKit
 
 let contentsViewController = ContentsViewController()
 contentsViewController.source = [

--- a/ListKitExample/ListKit.playground/Sources/ContentsViewController.swift
+++ b/ListKitExample/ListKit.playground/Sources/ContentsViewController.swift
@@ -1,10 +1,10 @@
-import UIKit
 import ListKit
+import UIKit
 
 public class ContentsViewController: UIViewController, UpdatableTableListAdapter {
     public typealias Item = (title: String, viewController: UIViewController.Type)
     public var source = [Item]()
-    
+
     public var tableList: TableList<ContentsViewController> {
         tableViewCellForRow { (context, item) -> UITableViewCell in
             let labelCell = context.dequeueReusableCell(UITableViewCell.self)
@@ -18,12 +18,12 @@ public class ContentsViewController: UIViewController, UpdatableTableListAdapter
             navigationController?.pushViewController(viewController, animated: true)
         }
     }
-    
+
     public override func viewDidLoad() {
         apply(by: tableView)
         title = "Contents"
     }
-    
+
     #if EXAMPLE
     convenience init() {
         self.init(nibName: nil, bundle: nil)
@@ -49,20 +49,18 @@ extension ContentsViewController {
     }
 }
 
-
 #if canImport(SwiftUI) && EXAMPLE
 import SwiftUI
 
 @available(iOS 13.0, *)
 struct Contents_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { Contents_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: ContentsViewController())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) { }
 }
 
 #endif
-

--- a/ListKitExample/ListKit.playground/Sources/CoreDataListViewController.swift
+++ b/ListKitExample/ListKit.playground/Sources/CoreDataListViewController.swift
@@ -6,18 +6,20 @@
 //
 
 import CoreData
-import UIKit
 import ListKit
+import UIKit
+
+// swiftlint: disable unused_closure_parameter comment_spacing
 
 public class CoreDataListViewController: UIViewController, UpdatableTableListAdapter {
     var fetchLimit = 3
-    
+
     public var toggle = true
     lazy var todosList = configTodosList()
     lazy var recent = configRecentList()
     lazy var loadMore = configLoadMore()
     lazy var tableView = _tableView
-    
+
     public typealias Item = Any
     public var source: AnyTableSources {
         AnyTableSources {
@@ -38,7 +40,7 @@ public class CoreDataListViewController: UIViewController, UpdatableTableListAda
             }
         }
     }
-    
+
     func configTodosList() -> ListFetchedResultsController<ToDo> {
         let fetchRequest = NSFetchRequest<ToDo>(entityName: ToDo.entityName)
         fetchRequest.sortDescriptors = [
@@ -60,7 +62,7 @@ public class CoreDataListViewController: UIViewController, UpdatableTableListAda
         try? controller.performFetch()
         return controller
     }
-    
+
     func configRecentList() -> ListFetchedResultsController<ToDo> {
         let fetchRequest = NSFetchRequest<ToDo>(entityName: ToDo.entityName)
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "createAt", ascending: false)]
@@ -72,7 +74,7 @@ public class CoreDataListViewController: UIViewController, UpdatableTableListAda
         try? controller.performFetch()
         return controller
     }
-    
+
     func configLoadMore() -> TableList<ItemSources<String>> {
         Sources(item: "loadmore")
             .tableViewCellForRow(UITableViewCell.self) { (cell, context, item) in
@@ -90,12 +92,12 @@ public class CoreDataListViewController: UIViewController, UpdatableTableListAda
                 }
             }
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         apply(by: tableView)
-        
+
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(
                 barButtonSystemItem: .add,
@@ -113,12 +115,12 @@ public class CoreDataListViewController: UIViewController, UpdatableTableListAda
 
 public class ToDo: NSManagedObject {
     class var entityName: String { "ToDo" }
-    
+
     @NSManaged var title: String
     @NSManaged var priority: Int16
     @NSManaged var done: Bool
     @NSManaged var createAt: Date
-    
+
     static func insert(title: String, priority: Int16) {
         #if EXAMPLE
         let toDo = ToDo(context: CoreDataListViewController.managedObjectContext)
@@ -144,7 +146,7 @@ extension ToDo {
         done.toggle()
         CoreDataListViewController.saveContext()
     }
-    
+
     func delete() {
         CoreDataListViewController.managedObjectContext.delete(self)
         CoreDataListViewController.saveContext()
@@ -159,7 +161,7 @@ extension NSManagedObject {
         didChangeValue(forKey: "done")
         CoreDataListViewController.saveContext()
     }
-    
+
     func delete() {
         CoreDataListViewController.managedObjectContext.delete(self)
         CoreDataListViewController.saveContext()
@@ -206,16 +208,16 @@ extension CoreDataListViewController {
         }
         return container
     }()
-    
+
     static var managedObjectContext: NSManagedObjectContext {
         persistentContainer.viewContext
     }
-    
+
     static func saveContext () {
         guard managedObjectContext.hasChanges else { return }
         try? managedObjectContext.save()
     }
-    
+
     var _tableView: UITableView {
         let tableView = UITableView(frame: view.bounds)
         tableView.allowsMultipleSelectionDuringEditing = true
@@ -223,33 +225,32 @@ extension CoreDataListViewController {
         tableView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         return tableView
     }
-    
+
     @objc func add() {
         let alert = UIAlertController(title: "Add ToDo", message: nil, preferredStyle: .alert)
         alert.addTextField { (textField) in
             textField.text = "Title"
             textField.selectAll(nil)
         }
-        
+
         alert.addTextField { (textField) in
             textField.placeholder = "priority"
             textField.keyboardType = .numberPad
         }
-        
+
         alert.addAction(UIAlertAction(title: "cancel", style: .cancel))
-        
+
         let ok = UIAlertAction(title: "Done", style: .default) { [unowned alert] _ in
             guard let title = alert.textFields?.first?.text, !title.isEmpty else { return }
             let priority = (alert.textFields?.last?.text).flatMap(Int16.init) ?? 0
             ToDo.insert(title: title, priority: priority)
         }
-        
+
         alert.addAction(ok)
         present(alert, animated: true)
         alert.textFields?.first?.selectAll(nil)
     }
 }
-
 
 #if canImport(SwiftUI) && EXAMPLE
 
@@ -258,11 +259,11 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct CoreDataList_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { CoreDataList_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: CoreDataListViewController())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) { }
 }
 
@@ -300,7 +301,7 @@ struct CoreDataList_Preview: UIViewControllerRepresentable, PreviewProvider {
 //            todosList
 //                .tableConfig()
 //                .tableViewHeaderTitleForSection { [unowned self] (context) -> String? in
-//                    self.todosList.sectionInfo[context.section].name == "0" ? "TODO" : "Done"
+//                    self.todosList.sectionInfo[context.section].name == "0" ? "Todo" : "Done"
 //                }
 //        }
 //    }

--- a/ListKitExample/ListKit.playground/Sources/DoubleListViewController.swift
+++ b/ListKitExample/ListKit.playground/Sources/DoubleListViewController.swift
@@ -1,21 +1,23 @@
-import UIKit
+// swiftlint: disable unused_closure_parameter
+
 import ListKit
+import UIKit
 
 public class DoubleListViewController: UIViewController, TableListAdapter, CollectionListAdapter, UpdatableDataSource {
     private let _models = ["Roy", "Pinlin", "Zhiyi", "Frain", "Jack", "Cookie", "Kubrick", "Jeremy", "Juhao", "Herry"]
-    
+
     public typealias Item = String
     public typealias ItemCache = CGSize
-    
+
     var toggle = false
-    
+
     public var source: [String] {
         var shuffledModels = _models.shuffled()
         shuffledModels.removeFirst()
         shuffledModels.removeLast()
         return shuffledModels.shuffled()
     }
-    
+
     public var scrollList: ScrollList<DoubleListViewController> {
         scrollViewDidEndDragging { _, _ in
             print("didEndDragging")
@@ -24,14 +26,14 @@ public class DoubleListViewController: UIViewController, TableListAdapter, Colle
             print("didDrag")
         }
     }
-    
+
     public var tableList: TableList<DoubleListViewController> {
         tableViewCellForRow()
         .tableViewDidSelectRow { [unowned self] (context, item) in
             perform(.remove(at: context.item))
         }
     }
-    
+
     public var collectionList: CollectionList<DoubleListViewController> {
         collectionViewCellForItem(CenterLabelCell.self) { (cell, _, item) in
             cell.text = "\(item)"
@@ -42,12 +44,12 @@ public class DoubleListViewController: UIViewController, TableListAdapter, Colle
         }
         .collectionViewLayoutInsetForSection(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         apply(by: collectionView)
         apply(by: tableView)
-        
+
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(
                 barButtonSystemItem: .refresh,
@@ -63,7 +65,7 @@ public class DoubleListViewController: UIViewController, TableListAdapter, Colle
     }
 }
 
-//UI
+// UI
 extension DoubleListViewController {
     final class CenterLabelCell: UICollectionViewCell {
         lazy private var label: UILabel = {
@@ -75,18 +77,18 @@ extension DoubleListViewController {
             self.contentView.addSubview(view)
             return view
         }()
-        
+
         var text: String? {
             get { return label.text }
             set { label.text = newValue }
         }
-        
+
         override func layoutSubviews() {
             super.layoutSubviews()
             label.frame = contentView.bounds
         }
     }
-    
+
     var tableView: UITableView {
         let halfHeight = view.bounds.height / 2
         let frame = CGRect(x: 0, y: 0, width: view.frame.width, height: halfHeight)
@@ -95,7 +97,7 @@ extension DoubleListViewController {
         tableView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         return tableView
     }
-    
+
     var collectionView: UICollectionView {
         let halfHeight = view.bounds.height / 2
         let frame = CGRect(x: 0, y: halfHeight, width: view.frame.width, height: halfHeight)
@@ -105,11 +107,11 @@ extension DoubleListViewController {
         collectionView.backgroundColor = .white
         return collectionView
     }
-    
+
     @objc func refresh() {
         performUpdate()
     }
-    
+
     @objc func add() {
 //        let alert = UIAlertController(title: "Add content", message: nil, preferredStyle: .alert)
 //        alert.addTextField { (textField) in
@@ -128,8 +130,6 @@ extension DoubleListViewController {
     }
 }
 
-
-
 #if canImport(SwiftUI) && EXAMPLE
 
 import SwiftUI
@@ -137,11 +137,11 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct DoubleList_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { DoubleList_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: DoubleListViewController())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) { }
 }
 
@@ -167,4 +167,3 @@ public extension DoubleListViewController {
 //        .diff(id: \.0) { $0.1 == $1.1 }
 //    }
 }
-

--- a/ListKitExample/ListKit.playground/Sources/IdentifiableSectionListViewController.swift
+++ b/ListKitExample/ListKit.playground/Sources/IdentifiableSectionListViewController.swift
@@ -1,5 +1,7 @@
-import UIKit
+// swiftlint:disable unused_closure_parameter comment_spacing
+
 import ListKit
+import UIKit
 
 public struct Room: UpdatableDataSource {
     public var coordinatorStorage = CoordinatorStorage<Room>()
@@ -10,12 +12,12 @@ public struct Room: UpdatableDataSource {
 extension Room: CollectionListAdapter, ItemCachedDataSource {
     public typealias Item = String
     public typealias ItemCache = String
-    
+
     public var source: [String] { people.shuffled() }
     public var listDiffer: ListDiffer<Room> { .diff(id: \.name) }
     public var listOptions: ListOptions { .removeEmptySection }
     public var itemCached: ItemCached<Room, String> { withItemCached { $0 } }
-    
+
     public var collectionList: CollectionList<Room> {
         collectionViewCellForItem(CenterLabelCell.self) { (cell, context, item) in
             cell.text = item
@@ -39,23 +41,23 @@ extension Room: CollectionListAdapter, ItemCachedDataSource {
 public class IdentifiableSectionListViewController: UIViewController, UpdatableCollectionListAdapter, ItemCachedDataSource {
     public typealias Item = String
     public typealias ItemCache = String
-    
+
     public var source: [Room] {
         Room.random
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         apply(by: collectionView)
-        
+
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .refresh,
             target: self,
             action: #selector(refresh)
         )
     }
-    
+
     @objc func refresh() {
         performUpdate()
     }
@@ -67,7 +69,7 @@ extension Room: CustomStringConvertible {
         "July", "Raynor", "Tonny", "Dooze", "Charlie", "Venry",
         "Bernard", "Mai", "Melissa", "Kippa", "Jerry"
     ]
-    
+
     static var random: [Room] {
         var shuffled = members.shuffled()
         var rooms = [
@@ -87,8 +89,7 @@ extension Room: CustomStringConvertible {
 
         return results.sorted { $0.people.count > $1.people.count }
     }
-    
-    
+
     init(_ name: String, _ people: [String]) {
         self.name = name
         self.people = people
@@ -97,7 +98,7 @@ extension Room: CustomStringConvertible {
         self.name = name
         self.people = people.map { "\($0)" }
     }
-    
+
     public var description: String { "Room(\"\(name)\", \(people))" }
 }
 
@@ -123,18 +124,18 @@ extension Room {
             self.contentView.addSubview(view)
             return view
         }()
-        
+
         var text: String? {
             get { return label.text }
             set { label.text = newValue }
         }
-        
+
         override func layoutSubviews() {
             super.layoutSubviews()
             label.frame = contentView.bounds
         }
     }
-    
+
     final class TitleHeader: UICollectionReusableView {
         lazy private var label: UILabel = {
             let view = UILabel(frame: bounds)
@@ -147,7 +148,7 @@ extension Room {
             self.addSubview(view)
             return view
         }()
-        
+
         lazy private var refreshButton: UIButton = {
             let button = UIButton(type: .system)
             button.setTitle("Refresh", for: .normal)
@@ -158,16 +159,16 @@ extension Room {
             self.addSubview(button)
             return button
         }()
-        
+
         var text: String? {
             get { return label.text }
             set { label.text = newValue }
         }
-        
+
         var refresh: (() -> Void)? {
             didSet { refreshButton.isHidden = refresh == nil }
         }
-        
+
         @objc func refreshAction() {
             refresh?()
         }
@@ -181,13 +182,13 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct IdentifiableSectionList_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { IdentifiableSectionList_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: IdentifiableSectionListViewController())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) {
-        
+
     }
 }
 

--- a/ListKitExample/ListKit.playground/Sources/NestedListViewController.swift
+++ b/ListKitExample/ListKit.playground/Sources/NestedListViewController.swift
@@ -1,14 +1,16 @@
-import UIKit
+// swiftlint:disable unused_closure_parameter
+
 import ListKit
+import UIKit
 
 public class NestedListViewController: UIViewController, UpdatableTableListAdapter {
     public typealias Item = Any
-    
+
     let nestedSources = Sources(items: 0..<10)
         .collectionViewCellForItem(CenterLabelCell.self) { (cell, context, item) in
             cell.text = "\(item)"
         }
-    
+
     public var source: AnyTableSources {
         AnyTableSources {
             Sources(item: nestedSources)
@@ -21,7 +23,7 @@ public class NestedListViewController: UIViewController, UpdatableTableListAdapt
                 .tableViewHeightForRow(50)
         }
     }
-    
+
     public override func viewDidLoad() {
         apply(by: tableView)
     }
@@ -39,13 +41,13 @@ extension NestedListViewController {
             self.contentView.addSubview(view)
             return view
         }()
-        
+
         override func layoutSubviews() {
             super.layoutSubviews()
             collectionView.frame = contentView.frame
         }
     }
-    
+
     final class CenterLabelCell: UICollectionViewCell {
         lazy private var label: UILabel = {
             let view = UILabel()
@@ -56,19 +58,19 @@ extension NestedListViewController {
             self.contentView.addSubview(view)
             return view
         }()
-        
+
         var text: String? {
             get { return label.text }
             set { label.text = newValue }
         }
-        
+
         override func layoutSubviews() {
             super.layoutSubviews()
             label.frame = contentView.bounds
         }
-        
+
     }
-    
+
     var tableView: UITableView {
         let tableView = UITableView(frame: view.bounds)
         view.addSubview(tableView)
@@ -77,7 +79,6 @@ extension NestedListViewController {
     }
 }
 
-
 #if canImport(SwiftUI) && EXAMPLE
 
 import SwiftUI
@@ -85,13 +86,13 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct NestedList_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { NestedList_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: NestedListViewController())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) {
-        
+
     }
 }
 

--- a/ListKitExample/ListKit.playground/Sources/SectionListViewControlle.swift
+++ b/ListKitExample/ListKit.playground/Sources/SectionListViewControlle.swift
@@ -1,16 +1,18 @@
-import UIKit
 import ListKit
+import UIKit
+
+// swiftlint:disable comment_spacing
 
 public class SectionListViewControlle: UIViewController, UpdatableCollectionListAdapter {
     static let emojis = (0x1F600...0x1F647).compactMap { UnicodeScalar($0) }
-    
+
     public typealias Item = UnicodeScalar
     public var source: [[UnicodeScalar]] {
         (0..<Int.random(in: 2...4)).map { _ in
             Array(Self.emojis.shuffled()[0..<Int.random(in: 20...30)])
         }
     }
-    
+
     public var collectionList: CollectionList<SectionListViewControlle> {
         collectionViewCellForItem(CenterLabelCell.self) { (cell, _, item) in
             cell.text = "\(item)"
@@ -18,24 +20,24 @@ public class SectionListViewControlle: UIViewController, UpdatableCollectionList
         .collectionViewLayoutSizeForItem(CGSize(width: 30, height: 30))
         .collectionViewLayoutInsetForSection(UIEdgeInsets(top: 20, left: 10, bottom: 20, right: 10))
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         apply(by: collectionView)
-           
+
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .refresh,
             target: self,
             action: #selector(refresh)
         )
     }
-    
+
     @objc func refresh() {
         performUpdate()
     }
 }
 
-//UI
+// UI
 extension SectionListViewControlle {
     final class CenterLabelCell: UICollectionViewCell {
         lazy private var label: UILabel = {
@@ -47,18 +49,18 @@ extension SectionListViewControlle {
             self.contentView.addSubview(view)
             return view
         }()
-        
+
         var text: String? {
             get { return label.text }
             set { label.text = newValue }
         }
-        
+
         override func layoutSubviews() {
             super.layoutSubviews()
             label.frame = contentView.bounds
         }
     }
-    
+
     var collectionView: UICollectionView {
         let collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: UICollectionViewFlowLayout())
         view.addSubview(collectionView)
@@ -75,13 +77,13 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct SectionList_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { SectionList_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: SectionListViewControlle())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) {
-        
+
     }
 }
 

--- a/ListKitExample/ListKit.playground/Sources/TestListViewController.swift
+++ b/ListKitExample/ListKit.playground/Sources/TestListViewController.swift
@@ -1,9 +1,11 @@
-import UIKit
 import ListKit
+import UIKit
+
+// swiftlint:disable comment_spacing
 
 public class TestListViewController: UIViewController, UpdatableTableListAdapter {
     public var toggle = true
-    
+
     lazy var itemSource = ItemSource()
     lazy var itemsSource = Sources(items: [1.0, 2.0, 3.0], options: .removeEmptySection)
         .tableViewCellForRow()
@@ -11,17 +13,19 @@ public class TestListViewController: UIViewController, UpdatableTableListAdapter
             self.batchRemove(at: context.item)
         }
         .tableViewHeaderTitleForSection("items")
-    
+
     final class ItemSource: UpdatableTableListAdapter {
+        // swiftlint: disable nesting
         public typealias Item = Any
+        // swiftlint: enable nesting
         var toggle = true
-        
+
         public var source: AnyTableSources {
             AnyTableSources {
                 if toggle {
                     Sources(item: true)
                         .tableViewCellForRow()
-                        .tableViewDidSelectRow { [unowned self] (context, item) in
+                        .tableViewDidSelectRow { [unowned self] (context, _) in
                             context.deselectItem(animated: false)
                             self.toggle.toggle()
                             self.performUpdate()
@@ -29,7 +33,7 @@ public class TestListViewController: UIViewController, UpdatableTableListAdapter
                 } else {
                     Sources(items: [false, false, false])
                         .tableViewCellForRow()
-                        .tableViewDidSelectRow { (context, item) in
+                        .tableViewDidSelectRow { (context, _) in
                             context.deselectItem(animated: false)
                             self.toggle.toggle()
                             self.performUpdate()
@@ -39,7 +43,7 @@ public class TestListViewController: UIViewController, UpdatableTableListAdapter
             .tableViewHeaderTitleForSection("item")
         }
     }
-    
+
     public typealias Item = Any
     public var source: AnyTableSources {
         AnyTableSources {
@@ -66,12 +70,12 @@ public class TestListViewController: UIViewController, UpdatableTableListAdapter
             }.tableViewHeaderTitleForSection("sources")
         }
     }
-    
+
     public override func viewDidLoad() {
         apply(by: tableView)
         configActions()
     }
-    
+
     func configActions() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .refresh,
@@ -79,12 +83,12 @@ public class TestListViewController: UIViewController, UpdatableTableListAdapter
             action: #selector(refresh)
         )
     }
-    
+
     @objc func refresh() {
         toggle.toggle()
         performUpdate()
     }
-    
+
     func batchRemove(at item: Int) {
         itemsSource.perform(.remove(at: item))
     }
@@ -106,13 +110,13 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct TestList_Preview: UIViewControllerRepresentable, PreviewProvider {
     static var previews: some View { TestList_Preview() }
-    
+
     func makeUIViewController(context: Self.Context) -> UINavigationController {
         UINavigationController(rootViewController: TestListViewController())
     }
-    
+
     func updateUIViewController(_ uiViewController: UINavigationController, context: Self.Context) {
-        
+
     }
 }
 

--- a/ListKitExample/SupportFiles/AppDelegate.swift
+++ b/ListKitExample/SupportFiles/AppDelegate.swift
@@ -5,8 +5,8 @@
 //  Created by Frain on 2020/4/23.
 //
 
-import UIKit
 import ListKit
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,11 +15,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         ListKit.Log.logger = { print($0) }
-        
+
         window = UIWindow()
         window?.rootViewController = UINavigationController(rootViewController: ContentsViewController())
         window?.makeKeyAndVisible()
         return true
     }
 }
-

--- a/Sources/Context/Context+UIKit.swift
+++ b/Sources/Context/Context+UIKit.swift
@@ -12,15 +12,15 @@ public extension ListIndexContext where Index == IndexPath, List: UIListView {
     func selectItem(animated: Bool, scrollPosition: List.ScrollPosition) {
         listView.selectItem(at: index, animated: animated, scrollPosition: scrollPosition)
     }
-    
+
     func deselectItem(animated: Bool) {
         listView.deselectItem(at: index, animated: animated)
     }
-    
+
     var cell: List.Cell? {
         listView.cellForItem(at: index)
     }
-    
+
     func dequeueReusableCell<CustomCell: UIView>(
         _ cellClass: CustomCell.Type,
         identifier: String = ""
@@ -42,7 +42,7 @@ public extension ListIndexContext where Index == IndexPath, List: UIListView {
             indexPath: index
         )
     }
-    
+
     func dequeueReusableCell<CustomCell: UIView>(
         _ cellClass: CustomCell.Type,
         withNibName nibName: String,
@@ -58,11 +58,11 @@ public extension ListIndexContext where Index == IndexPath, List: UIListView {
 }
 
 public extension ListIndexContext where Index == IndexPath, List: UICollectionView {
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UICollectionReusableView>(
+    func dequeueReusableSupplementaryView<SupplementaryView: UICollectionReusableView>(
         type: UICollectionView.SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         identifier: String = ""
-    ) -> CustomSupplementaryView {
+    ) -> SupplementaryView {
         listView.dequeueReusableSupplementaryView(
             type: type,
             supplementaryClass,
@@ -70,13 +70,13 @@ public extension ListIndexContext where Index == IndexPath, List: UICollectionVi
             indexPath: index
         )
     }
-    
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UICollectionReusableView>(
+
+    func dequeueReusableSupplementaryView<SupplementaryView: UICollectionReusableView>(
         type: UICollectionView.SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         nibName: String,
         bundle: Bundle? = nil
-    ) -> CustomSupplementaryView {
+    ) -> SupplementaryView {
         listView.dequeueReusableSupplementaryView(
             type: type,
             supplementaryClass,
@@ -88,25 +88,25 @@ public extension ListIndexContext where Index == IndexPath, List: UICollectionVi
 }
 
 public extension Context where List: UITableView {
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UITableViewHeaderFooterView>(
+    func dequeueReusableSupplementaryView<SupplementaryView: UITableViewHeaderFooterView>(
         type: UITableView.SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         identifier: String = "",
-        configuration: (CustomSupplementaryView) -> Void = { _ in }
-    ) -> CustomSupplementaryView? {
+        configuration: (SupplementaryView) -> Void = { _ in }
+    ) -> SupplementaryView? {
         listView.dequeueReusableSupplementaryView(
             type: type,
             supplementaryClass,
             identifier: identifier
         )
     }
-    
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UITableViewHeaderFooterView>(
+
+    func dequeueReusableSupplementaryView<SupplementaryView: UITableViewHeaderFooterView>(
         type: UITableView.SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         nibName: String,
         bundle: Bundle? = nil
-    ) -> CustomSupplementaryView? {
+    ) -> SupplementaryView? {
         listView.dequeueReusableSupplementaryView(
             type: type,
             supplementaryClass,
@@ -117,6 +117,3 @@ public extension Context where List: UITableView {
 }
 
 #endif
-
-
-

--- a/Sources/Context/ListContext.swift
+++ b/Sources/Context/ListContext.swift
@@ -11,7 +11,7 @@ import Foundation
 public protocol Context {
     associatedtype Base: DataSource
     associatedtype List
-    
+
     var source: Base.SourceBase.Source { get }
     var listView: List { get }
 }
@@ -20,7 +20,7 @@ public struct ListContext<List, Base: DataSource>: Context {
     public let listView: List
     let context: ListCoordinatorContext<Base.SourceBase>
     let root: CoordinatorContext
-    
+
     public var source: Base.SourceBase.Source { context.listCoordinator.source }
 }
 
@@ -30,7 +30,7 @@ public struct ListIndexContext<List, Base: DataSource, Index>: Context {
     public let offset: Index
     let context: ListCoordinatorContext<Base.SourceBase>
     let root: CoordinatorContext
-    
+
     public var source: Base.SourceBase.Source { context.listCoordinator.source }
 }
 
@@ -52,7 +52,7 @@ public extension ListIndexContext where Index == Int {
 public extension ListIndexContext where Index == IndexPath {
     var section: Int { index.section - offset.section }
     var item: Int { index.item - offset.item }
-    
+
     var itemValue: Base.SourceBase.Item {
         context.listCoordinator.item(at: index.offseted(offset, plus: false))
     }
@@ -66,7 +66,7 @@ extension ListIndexContext where Index == IndexPath {
     func setNestedCache(update: @escaping (Any) -> Void) {
         root.itemNestedCache[index.section][index.item] = update
     }
-    
+
     func cache<Cache>() -> Cache {
         if let cache = root.itemCaches[index.section][index.item] as? Cache { return cache }
         return context.listCoordinator.cache(

--- a/Sources/Coordinator/CoordinatorUpdate/CollectionCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/CollectionCoordinatorUpdate.swift
@@ -5,10 +5,11 @@
 //  Created by Frain on 2020/7/5.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
-class CollectionCoordinatorUpdate<SourceBase, Source, Value, Change, DifferenceChange>:
-    ListCoordinatorUpdate<SourceBase>
+class CollectionCoordinatorUpdate<SourceBase, Source, Value, Change, DifferenceChange>: ListCoordinatorUpdate<SourceBase>
 where
     SourceBase: DataSource,
     SourceBase.SourceBase == SourceBase,
@@ -20,25 +21,25 @@ where
     typealias Changes = Mapping<ContiguousArray<Change>>
     typealias Difference = CoordinatorUpdate.Difference<DifferenceChange>
     typealias Differences = Mapping<ContiguousArray<Difference>>
-    
+
     let sourceValues: Values
-    
+
     lazy var targetValues = configTargetValues()
     lazy var differences = configDifferences()
     lazy var diffs = configDiffs()
     lazy var changes = configChanges()
     lazy var uniqueMapping = configUniqueMapping()
     lazy var uniqueDict = configUniqueDict()
-    
+
     lazy var appendValues = Values()
     lazy var changeIndices: Mapping<IndexSet> = (.init(), .init())
     lazy var changeDict: Mapping<[Int: Change]> = ([:], [:])
     lazy var updateDict = [Int: (change: Change, value: Value)]()
-    
+
     var equatable: Bool { false }
     var identifiable: Bool { false }
     var shouldConsiderUpdate: Bool { !updateDict.isEmpty }
-    
+
     init(
         _ coordinator: ListCoordinator<SourceBase>,
         update: ListUpdate<SourceBase>?,
@@ -50,36 +51,36 @@ where
         super.init(coordinator, update: update, sources: sources, options: options)
         if !isBatchUpdate { self.targetValues = values.target }
     }
-    
+
     func isEqual(lhs: Value, rhs: Value) -> Bool { notImplemented() }
     func identifier(for value: Value) -> AnyHashable { notImplemented() }
     func isDiffEqual(lhs: Value, rhs: Value) -> Bool { notImplemented() }
     func associateChange(_ mapping: Mapping<Change>, ids: Mapping<[AnyHashable]>) { }
-    
+
     func toValue(_ element: Element) -> Value { notImplemented() }
     func toCount(_ value: Value) -> Int { 1 }
     func toChange(_ value: Value, _ index: Int) -> Change { notImplemented() }
     func toSource(_ values: ContiguousArray<Value>) -> SourceBase.Source? { notImplemented() }
-    
+
     func add(change: Change, isSource: Bool, to differences: inout Differences) { notImplemented() }
-    
+
     func canConfig(at index: Mapping<Int>) -> Bool { updateDict[index.source] != nil }
     func configUpdate(at index: Mapping<Int>, into differences: inout Differences) {
         guard let (source, value) = updateDict[index.source] else { fatalError() }
         let target = toChange(value, index.target)
         (source[[]], target[[]]) = (.init(change: target), .init(change: source))
         (source.state, target.state) = (.reload, .reload)
-        
+
         add(change: source, isSource: true, to: &differences)
         add(change: target, isSource: false, to: &differences)
     }
-    
+
     func configTargetValues() -> Values {
         enumerateChangesForTarget(offset: { (from, to, source, target) in
             target.append(contentsOf: source[from..<to])
         }, append: { $1.append($0) })
     }
-    
+
     func configChangesForDiffs() -> Changes {
         func convert(values: Values) -> ContiguousArray<Change> {
             var index = 0
@@ -88,22 +89,22 @@ where
                 return toChange($0, index)
             }
         }
-        
+
         if isRemove { return (convert(values: sourceValues), .init()) }
         if isInsert { return (.init(), convert(values: targetValues)) }
-        
+
         switch changeType {
         case .none, .other(.reload): return (.init(), .init())
         case .other(.remove): return (convert(values: sourceValues), .init())
         case .other(.insert): return (.init(), convert(values: targetValues))
         default: break
         }
-        
+
         let sourceChange = diffs.removals.mapContiguous { toChange($0._element, $0._offset) }
         let targetChange = diffs.insertions.mapContiguous { toChange($0._element, $0._offset) }
         return (sourceChange, targetChange)
     }
-    
+
     override func configTarget() -> SourceBase.Source? { toSource(targetValues) }
 }
 
@@ -113,17 +114,17 @@ extension CollectionCoordinatorUpdate {
         changes.source.append(.unchanged(from: from, to: to))
         changes.target.append(.unchanged(from: from, to: to))
     }
-    
+
     func enumerateUnchanged(from: Mapping<Int>, to: Mapping<Int>, to diffs: inout Differences) {
         var last = from
-        for i in zip(from.source..<to.source, from.target..<to.target) where canConfig(at: i) {
-            append(from: last, to: i, to: &diffs)
-            configUpdate(at: i, into: &diffs)
-            (last.source, last.target) = (i.0 + 1, i.1 + 1)
+        for index in zip(from.source..<to.source, from.target..<to.target) where canConfig(at: index) {
+            append(from: last, to: index, to: &diffs)
+            configUpdate(at: index, into: &diffs)
+            (last.source, last.target) = (index.0 + 1, index.1 + 1)
         }
         append(from: last, to: to, to: &diffs)
     }
-    
+
     func configChanges() -> Changes {
         guard isBatchUpdate else { return configChangesForDiffs() }
         let count: Mapping<Int> = (changeDict.source.count, changeDict.target.count)
@@ -137,7 +138,7 @@ extension CollectionCoordinatorUpdate {
         }
         return changes
     }
-    
+
     func configUniqueDict() -> Mapping<Uniques<Change>> {
         let source = Uniques<Change>(minimumCapacity: changes.source.count)
         let target = Uniques<Change>(minimumCapacity: changes.target.count)
@@ -147,17 +148,17 @@ extension CollectionCoordinatorUpdate {
         if identifiable { apply(changes, dict: &result) { $0 } }
         return result
     }
-    
+
     func configDiffs() -> CollectionDifference<Value> {
         CollectionDifference(from: sourceValues, to: targetValues, by: isDiffEqual)
     }
-    
+
     func configUniqueMapping() -> Changes {
         let source = uniqueDict.source.values.compactMapContiguous { $0?.change }
         let target = uniqueDict.target.values.compactMapContiguous { $0?.change }
         return (source, target)
     }
-    
+
     func configDifferences() -> Differences {
         let capacity = sourceValues.count + targetValues.count
         var result: Differences = (.init(capacity: capacity), .init(capacity: capacity))
@@ -172,7 +173,7 @@ extension CollectionCoordinatorUpdate {
         })
         return result
     }
-    
+
     func apply<T, C: Collection>(
         _ changes: Mapping<C>,
         dict: inout Mapping<Uniques<T>>,
@@ -183,7 +184,7 @@ extension CollectionCoordinatorUpdate {
             let euqal = equatable ? isEqual : nil
             config(for: change, key, &dict, euqal, associateChange, toChange)
         }
-        
+
         changes.source.forEach { configAssociated(for: $0) }
         changes.target.forEach { configAssociated(for: $0) }
     }
@@ -193,7 +194,7 @@ extension CollectionCoordinatorUpdate {
     func enumerateChanges(changes: Changes, _ body: (Bool, Change) -> Void) {
         let total: Mapping = (changes.source.count, changes.target.count)
         var enumerated: Mapping = (0, 0)
-        
+
         while enumerated.source < total.source || enumerated.target < total.target {
             let change: Change, isSoure: Bool
             if enumerated.source < total.source && enumerated.target < total.target {
@@ -212,13 +213,13 @@ extension CollectionCoordinatorUpdate {
                 // Not reached, loop should have exited.
                 preconditionFailure()
             }
-            
+
             body(isSoure, change)
-            
+
             isSoure ? (enumerated.source += 1) : (enumerated.target += 1)
         }
     }
-    
+
     func enumerateChangesWithOffset(
         body: (Bool, Change) -> Void,
         offset: (Mapping<Int>, Mapping<Int>) -> Void
@@ -226,7 +227,7 @@ extension CollectionCoordinatorUpdate {
         var enumeratedChanges: Mapping = (0, 0)
         var enumeratedOriginals: Mapping = (0, 0)
         var index: Mapping = (0, 0)
-        
+
         enumerateChanges(changes: changes) { (isSource, change) in
             let current = enumerate(
                 change: change,
@@ -250,12 +251,12 @@ extension CollectionCoordinatorUpdate {
             }
             body(isSource, change)
         }
-        
+
         let remaining = sourceValues.count - index.source
         guard remaining > 0, targetValues.count > index.target else { return }
         offset(index, (index.source + remaining, index.target + remaining))
     }
-    
+
     func enumerateChangesForTarget(
         offset: (Int, Int, Values, inout Values) -> Void,
         append: (Value, inout Values) -> Void
@@ -290,10 +291,10 @@ extension CollectionCoordinatorUpdate {
         if currentIndex < sourceValues.endIndex {
             offset(currentIndex, sourceValues.endIndex, sourceValues, &target)
         }
-        
+
         return target
     }
-    
+
     func enumerate<Collection: RangeReplaceableCollection>(
         change: Change,
         in value: Collection,
@@ -307,7 +308,8 @@ extension CollectionCoordinatorUpdate {
         defer { index = value.index(after: index) }
         return (start, index)
     }
-    
+
+    // swiftlint:disable function_parameter_count
     func enumerate<Collection: RangeReplaceableCollection>(
         change: Change,
         in value: Collection,
@@ -322,6 +324,7 @@ extension CollectionCoordinatorUpdate {
         enumeratedOriginals += origCount
         return (start, index)
     }
+    // swiftlint:enable function_parameter_count
 }
 
 extension CollectionCoordinatorUpdate {
@@ -330,7 +333,7 @@ extension CollectionCoordinatorUpdate {
         changeIndices.target.insert(index)
         changeDict.target[index] = toChange(value, index)
     }
-    
+
     func insertElements<C: Collection>(contentsOf elements: C, at index: Int) where Element == C.Element {
         guard !elements.isEmpty else { return }
         var upper = index
@@ -341,30 +344,30 @@ extension CollectionCoordinatorUpdate {
         }
         changeIndices.target.insert(integersIn: index..<upper)
     }
-    
+
     func appendElement(_ element: Element) {
         appendValues.append(toValue(element))
     }
-    
+
     func appendElements<S: Sequence>(contentsOf elements: S) where Element == S.Element {
         appendValues.append(contentsOf: elements.map(toValue))
     }
-    
+
     func removeElement(at index: Int) {
         changeIndices.source.insert(index)
         changeDict.source[index] = toChange(sourceValues[index], index)
     }
-    
+
     func removeElements(at indexSet: IndexSet) {
         changeIndices.source.formUnion(indexSet)
         indexSet.forEach { changeDict.source[$0] = toChange(sourceValues[$0], $0) }
     }
-    
+
     func updateElement(_ element: Element, at index: Int) {
         let sourceChange = toChange(sourceValues[index], index)
         updateDict[index] = (sourceChange, toValue(element))
     }
-    
+
     func moveElement(at index: Int, to newIndex: Int) {
         changeIndices.source.insert(index)
         changeIndices.target.insert(newIndex)

--- a/Sources/Coordinator/CoordinatorUpdate/ItemCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/ItemCoordinatorUpdate.swift
@@ -11,34 +11,34 @@ final class ItemCoordinatorUpdate<SourceBase: DataSource>: ListCoordinatorUpdate
 where SourceBase.Item == SourceBase.Source, SourceBase.SourceBase == SourceBase {
     lazy var changes = configChanges()
     lazy var extraChange = Cache(value: (nil, nil) as Mapping<Change<Item>?>)
-    
+
     override var moveAndReloadable: Bool { !noneDiffUpdate }
-    
+
     override func configSourceCount() -> Int { 1 }
     override func configTargetCount() -> Int { 1 }
-    
+
     override func customUpdateWay() -> UpdateWay? {
         diffable && (changes.source != nil || changes.target != nil) ? .batch : nil
     }
-    
+
     func toChange(_ value: Item, _ index: Int) -> Change<Item> {
         let change = Change(value: value, index: index, moveAndReloadable: true)
         change.coordinatorUpdate = self
         return change
     }
-    
+
     func configChanges() -> Mapping<Change<Item>?> {
-        guard let s = source, let t = target else { return (nil, nil) }
+        guard let source = source, let target = target else { return (nil, nil) }
         switch updateWay {
-        case .other(.insert): return (nil, toChange(t, 0))
-        case .other(.remove): return (toChange(s, 0), nil)
+        case .other(.insert): return (nil, toChange(target, 0))
+        case .other(.remove): return (toChange(source, 0), nil)
         default: break
         }
         guard diffable else { return (nil, nil) }
-        let isEqual = differ.diffEqual(lhs: s, rhs: t)
-        return isEqual ? (nil, nil) : (toChange(s, 0), toChange(t, 0))
+        let isEqual = differ.diffEqual(lhs: source, rhs: target)
+        return isEqual ? (nil, nil) : (toChange(source, 0), toChange(target, 0))
     }
-    
+
     override func inferringMoves(context: Context? = nil, ids: [AnyHashable] = []) {
         guard diffable,
               let id = differ.identifier,
@@ -53,7 +53,7 @@ where SourceBase.Item == SourceBase.Source, SourceBase.SourceBase == SourceBase 
         changes.source.map { config(for: $0, key.source, &context.dicts, differ.areEquivalent) }
         changes.target.map { config(for: $0, key.target, &context.dicts, differ.areEquivalent) }
     }
-    
+
     override func generateSourceItemUpdate(
         order: Order,
         context: UpdateContext<IndexPath> = (nil, false, [])
@@ -71,7 +71,7 @@ where SourceBase.Item == SourceBase.Source, SourceBase.SourceBase == SourceBase 
             return (1, update)
         }
     }
-    
+
     override func generateTargetItemUpdate(
         order: Order,
         context: UpdateContext<Offset<IndexPath>> = (nil, false, [])
@@ -92,7 +92,7 @@ where SourceBase.Item == SourceBase.Source, SourceBase.SourceBase == SourceBase 
                 let target = context.offset?.offset.target ?? .zero
                 update.move(source, to: target)
             }
-            
+
             let change: (() -> Void)?
             if hasNext(order, context) {
                 let source = extraChange[context].source?.value

--- a/Sources/Coordinator/CoordinatorUpdate/ItemsCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/ItemsCoordinatorUpdate.swift
@@ -5,16 +5,17 @@
 //  Created by Frain on 2020/6/10.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
-class ItemsCoordinatorUpdate<SourceBase: DataSource>:
-    CollectionCoordinatorUpdate<
-        SourceBase,
-        SourceBase.Source,
-        SourceBase.Item,
-        CoordinatorUpdate.Change<SourceBase.Item>,
-        CoordinatorUpdate.Change<SourceBase.Item>
-    >
+class ItemsCoordinatorUpdate<SourceBase: DataSource>: CollectionCoordinatorUpdate<
+    SourceBase,
+    SourceBase.Source,
+    SourceBase.Item,
+    CoordinatorUpdate.Change<SourceBase.Item>,
+    CoordinatorUpdate.Change<SourceBase.Item>
+>
 where
     SourceBase.SourceBase == SourceBase,
     SourceBase.Source: Collection,
@@ -22,15 +23,15 @@ where
 {
     typealias Source = SourceBase.Source
     typealias Change = CoordinatorUpdate.Change<SourceBase.Item>
-    
+
     weak var coordinator: ItemsCoordinator<SourceBase>?
-    
+
     lazy var extraValues = Cache(value: ContiguousArray<Item>())
     lazy var extraChanges = Cache(value: ([], []) as Changes)
-    
+
     override var equatable: Bool { differ?.areEquivalent != nil }
     override var identifiable: Bool { differ?.identifier != nil }
-    
+
     required init(
         coordinator: ItemsCoordinator<SourceBase>,
         update: ListUpdate<SourceBase>?,
@@ -41,31 +42,31 @@ where
         self.coordinator = coordinator
         super.init(coordinator, update: update, values: values, sources: sources, options: options)
     }
-    
+
     override func isEqual(lhs: Item, rhs: Item) -> Bool { differ.equal(lhs: lhs, rhs: rhs) }
     override func identifier(for value: Item) -> AnyHashable { differ.identifier!(value) }
     override func isDiffEqual(lhs: Item, rhs: Item) -> Bool { differ.diffEqual(lhs: lhs, rhs: rhs) }
-    
+
     override func toValue(_ element: Element) -> Item { element }
-    
+
     override func toChange(_ value: Item, _ index: Int) -> Change {
         let change = Change(value: value, index: index, moveAndReloadable: moveAndReloadable)
         change.coordinatorUpdate = self
         return change
     }
-    
+
     override func add(change: Change, isSource: Bool, to changes: inout Differences) {
         changes[keyPath: path(isSource)].append(.change(change))
     }
-    
+
     override func configSourceCount() -> Int { sourceValues.count }
     override func configTargetCount() -> Int { targetValues.count }
-    
+
     override func updateData(_ isSource: Bool, containsSubupdate: Bool) {
         super.updateData(isSource, containsSubupdate: containsSubupdate)
         coordinator?.items = isSource ? sourceValues : targetValues
     }
-    
+
     override func inferringMoves(context: Context? = nil, ids: [AnyHashable] = []) {
         guard identifiable else { return }
         _ = uniqueDict
@@ -75,13 +76,13 @@ where
         target.forEach { add($0, id: identifier(for: $0.value), ids: ids, to: &context.dicts.target) }
         apply(uniqueMapping, dict: &context.dicts) { $0 as? Change }
     }
-    
+
     override func customUpdateWay() -> UpdateWay? {
         if isBatchUpdate { return .batch }
         guard diffable else { return .other(.reload) }
         return diffs.isEmpty ? nil : .batch
     }
-    
+
     override func generateSourceItemUpdate(
         order: Order,
         context: UpdateContext<IndexPath> = (nil, false, [])
@@ -104,7 +105,7 @@ where
             return (sourceCount, update)
         }
     }
-    
+
     override func generateTargetItemUpdate(
         order: Order,
         context: UpdateContext<Offset<IndexPath>> = (nil, false, [])
@@ -135,7 +136,7 @@ where
                     )
                 }
             }
-            
+
             let change: (() -> Void)?
             if hasNext(order, context) {
                 let values = extraValues[context], source = toSource(values)
@@ -151,8 +152,7 @@ where
     }
 }
 
-final class RangeReplacableItemsCoordinatorUpdate<SourceBase>:
-    ItemsCoordinatorUpdate<SourceBase>
+final class RangeReplacableItemsCoordinatorUpdate<SourceBase>: ItemsCoordinatorUpdate<SourceBase>
 where
     SourceBase: DataSource,
     SourceBase.SourceBase == SourceBase,
@@ -161,42 +161,42 @@ where
 {
     override var moveAndReloadable: Bool { !noneDiffUpdate }
     override func toSource(_ items: ContiguousArray<Item>) -> SourceBase.Source? { .init(items) }
-    
+
     override func insert(_ element: SourceBase.Source.Element, at index: Int)
     where SourceBase.Source: RangeReplaceableCollection {
         insertElement(element, at: index)
     }
-        
+
     override func insert<C: Collection>(contentsOf elements: C, at index: Int)
     where SourceBase.Source: RangeReplaceableCollection, C.Element == SourceBase.Source.Element {
         insertElements(contentsOf: elements, at: index)
     }
-        
+
     override func append(_ element: SourceBase.Source.Element)
     where SourceBase.Source: RangeReplaceableCollection {
         appendElement(element)
     }
-        
+
     override func append<S: Sequence>(contentsOf elements: S)
     where SourceBase.Source: RangeReplaceableCollection, S.Element == SourceBase.Source.Element {
         appendElements(contentsOf: elements)
     }
-        
+
     override func remove(at index: Int)
     where SourceBase.Source: RangeReplaceableCollection {
         removeElement(at: index)
     }
-    
+
     override func remove(at indexSet: IndexSet)
     where SourceBase.Source: RangeReplaceableCollection {
         removeElements(at: indexSet)
     }
-        
+
     override func update(_ element: SourceBase.Source.Element, at index: Int)
     where SourceBase.Source: RangeReplaceableCollection {
         updateElement(element, at: index)
     }
-        
+
     override func move(at index: Int, to newIndex: Int)
     where SourceBase.Source: RangeReplaceableCollection {
         moveElement(at: index, to: newIndex)

--- a/Sources/Coordinator/CoordinatorUpdate/ListCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/ListCoordinatorUpdate.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/8/3.
 //
 
+// swiftlint:disable shorthand_operator
+
 import Foundation
 
 class ListCoordinatorUpdate<SourceBase: DataSource>: CoordinatorUpdate
@@ -12,29 +14,29 @@ where SourceBase.SourceBase == SourceBase {
     typealias Item = SourceBase.Item
     typealias Sources = Mapping<SourceBase.Source?>
     typealias Options = Mapping<ListOptions>
-    
+
     weak var listCoordinator: ListCoordinator<SourceBase>?
     let source: SourceBase.Source?
     let sourceType: SourceType
     var updateWay: ListUpdateWay<SourceBase.Item>
     var differ: ListDiffer<SourceBase.Item>!
     var isBatchUpdate = false
-    
+
     lazy var target = configTarget()
     lazy var suboperations = [() -> Void]()
     lazy var sourceCount = configSourceCount()
     lazy var targetCount = configTargetCount()
-    
+
     lazy var changeType = configUpdateWay()
     lazy var cachedMaxOrder = Cache(value: nil as Order??)
-    
+
     var diffable: Bool { differ?.isNone == false }
     var moveAndReloadable: Bool { false }
     var isRemove: Bool {
         guard case .other(.remove) = updateWay else { return false }
         return true
     }
-    
+
     var noneDiffUpdate: Bool {
         if isBatchUpdate { return false }
         switch changeType {
@@ -42,22 +44,24 @@ where SourceBase.SourceBase == SourceBase {
         default: return true
         }
     }
-    
+
     var isInsert: Bool {
         guard case .other(.insert) = updateWay else { return false }
         return true
     }
-    
+
+    // swiftlint:disable unused_setter_value
     var section: ChangeSets<IndexSet> {
         get { fatalError() }
         set { }
     }
-    
+
     var item: ChangeSets<IndexPathSet> {
         get { fatalError() }
         set { }
     }
-    
+    // swiftlint:enable unused_setter_value
+
     init(
         _ coordinator: ListCoordinator<SourceBase>,
         update: ListUpdate<SourceBase>?,
@@ -96,12 +100,12 @@ where SourceBase.SourceBase == SourceBase {
             break
         }
     }
-    
+
     func configTarget() -> SourceBase.Source? { source }
     func configSourceCount() -> Int { notImplemented() }
     func configTargetCount() -> Int { notImplemented() }
     func inferringMoves(context: Context? = nil, ids: [AnyHashable] = []) { }
-    
+
     func configMaxOrderForContext(_ ids: [AnyHashable]) -> Order? {
         switch (sourceType, changeType) {
         case (.sectionItems, _) where targetHasSection != sourceHasSection: break
@@ -112,14 +116,14 @@ where SourceBase.SourceBase == SourceBase {
         case (_, .batch) where moveType(ids) == .moveAndReload: return .third
         case (_, _): return .second
         }
-        
+
         switch (targetHasSection && !sourceHasSection, moveType(ids)) {
         case (_, .none): return .first
         case (true, .some): return .second
         case (false, .some): return .third
         }
     }
-    
+
     func customUpdateWay() -> UpdateWay? { notImplemented() }
     func configUpdateWay() -> UpdateWay? {
         switch (updateWay, sourceCount == 0, targetCount == 0) {
@@ -133,7 +137,7 @@ where SourceBase.SourceBase == SourceBase {
         default: return customUpdateWay()
         }
     }
-    
+
     func generateSourceUpdate(
         order: Order,
         context: UpdateContext<Int> = (nil, false, [])
@@ -151,7 +155,7 @@ where SourceBase.SourceBase == SourceBase {
             return (sourceCountForContainer, .init(item: itemUpdate))
         }
     }
-    
+
     func generateTargetUpdate(
         order: Order,
         context: UpdateContext<Offset<Int>> = (nil, false, [])
@@ -174,50 +178,50 @@ where SourceBase.SourceBase == SourceBase {
             return (indices, .init(item: itemUpdate), change)
         }
     }
-    
+
     func generateSourceItemUpdate(
         order: Order,
         context: UpdateContext<IndexPath> = (nil, false, [])
     ) -> UpdateSource<BatchUpdates.ItemSource> {
         notImplemented()
     }
-    
+
     func generateTargetItemUpdate(
         order: Order,
         context: UpdateContext<Offset<IndexPath>> = (nil, false, [])
     ) -> UpdateTarget<BatchUpdates.ItemTarget> {
         notImplemented()
     }
-    
+
     // element batch update
     func insert(_ element: SourceBase.Source.Element, at index: Int)
     where SourceBase.Source: RangeReplaceableCollection { }
-        
+
     func insert<C: Collection>(contentsOf elements: C, at index: Int)
     where SourceBase.Source: RangeReplaceableCollection, C.Element == SourceBase.Source.Element { }
-        
+
     func append(_ element: SourceBase.Source.Element)
     where SourceBase.Source: RangeReplaceableCollection { }
-        
+
     func append<S: Sequence>(contentsOf elements: S)
     where SourceBase.Source: RangeReplaceableCollection, S.Element == SourceBase.Source.Element { }
-        
+
     func remove(at index: Int)
     where SourceBase.Source: RangeReplaceableCollection { }
-    
+
     func remove(at indexSet: IndexSet)
     where SourceBase.Source: RangeReplaceableCollection { }
-        
+
     func update(_ element: SourceBase.Source.Element, at index: Int)
     where SourceBase.Source: RangeReplaceableCollection { }
-        
+
     func move(at index: Int, to newIndex: Int)
     where SourceBase.Source: RangeReplaceableCollection { }
-    
+
     override func generateListUpdates() -> BatchUpdates? {
         sourceType.isItems ? generateListUpdatesForItems() : generateListUpdatesForSections()
     }
-    
+
     override func updateData(_ isSource: Bool, containsSubupdate: Bool) {
         listCoordinator?.source = isSource ? source : target
         listCoordinator?.options = isSource ? options.source : options.target
@@ -242,23 +246,23 @@ extension ListCoordinatorUpdate {
             default:
                 break
             }
-            
+
             var subupdate = generateSourceUpdate(order: order, context: context)
             if order == .second, targetHasSection && !sourceHasSection { subupdate.count = 1 }
             return subupdate
         }
-        
+
         switch changeType {
         case .none: return (sourceCountForContainer, nil)
-        case .other(let way) where way == .remove && moveType(context) != nil,
-             .other(let way) where way != .reload && isSectionItems: fallthrough
+        case .other(let way) where way == .remove && moveType(context) != nil: fallthrough
+        case .other(let way) where way != .reload && isSectionItems: fallthrough
         case .batch: return generateSourceUpdate(order: order, context: context)
         case .other(.insert): return (sourceCountForContainer, nil)
         case .other(let way): update = .init(section: sourceUpdate(way, context, isSectionItems))
         }
         return (sourceCountForContainer, update)
     }
-    
+
     func generateContianerTargetUpdate(
         order: Order,
         context: UpdateContext<Offset<Int>> = (nil, false, [])
@@ -282,7 +286,7 @@ extension ListCoordinatorUpdate {
             default:
                 break
             }
-            
+
             var subupdate = generateTargetUpdate(order: order, context: context)
             switch order {
             case .first:
@@ -295,19 +299,19 @@ extension ListCoordinatorUpdate {
             }
             return subupdate
         }
-        
-        var c: () -> Void { hasNext(order, context) ? firstChange(true) : finalChange(true) }
+
+        var change: () -> Void { hasNext(order, context) ? firstChange(true) : finalChange(true) }
         switch changeType {
         case .none: return (toIndices(targetCountForContainer, context), nil, nil)
-        case .other(let way) where way == .insert && moveType(context) != nil,
-             .other(let way) where way != .reload && isSectionItems: fallthrough
+        case .other(let way) where way == .insert && moveType(context) != nil: fallthrough
+        case .other(let way) where way != .reload && isSectionItems: fallthrough
         case .batch: return generateTargetUpdate(order: order, context: context)
-        case .other(.remove): return (toIndices(targetCountForContainer, context), nil, c)
+        case .other(.remove): return (toIndices(targetCountForContainer, context), nil, change)
         case .other(let way): update = .init(section: targetUpdate(way, context, isSectionItems))
         }
         return (toIndices(targetCountForContainer, context), update, finalChange(true))
     }
-    
+
     func generateSourceItemUpdateForContianer(
         order: Order,
         context: UpdateContext<IndexPath> = (nil, false, [])
@@ -319,7 +323,7 @@ extension ListCoordinatorUpdate {
         case .other(let way): return (sourceCount, sourceUpdate(way, context))
         }
     }
-    
+
     func generateTargetItemUpdateForContianer(
         order: Order,
         context: UpdateContext<Offset<IndexPath>> = (nil, false, [])
@@ -339,56 +343,56 @@ extension ListCoordinatorUpdate {
 extension ListCoordinatorUpdate {
     func sourceUpdate<C: UpdateIndexCollection>(
         _ way: ListKit.UpdateWay,
-        _ offset: UpdateContext<C.Element> = (nil, false, []),
+        _ context: UpdateContext<C.Element> = (nil, false, []),
         _ forContainer: Bool = false
     ) -> BatchUpdates.Source<C>? {
-        let o = offset.offset ?? .zero
+        let offset = context.offset ?? .zero
         let source = forContainer ? sourceCountForContainer : sourceCount
         let target = forContainer ? targetCountForContainer : targetCount
         switch way {
         case .remove:
-            return .init(\.deletes, o, o.offseted(source))
+            return .init(\.deletes, offset, offset.offseted(source))
         case .appendOrRemoveLast where sourceCount > targetCount:
-            return .init(\.deletes, o.offseted(target), o.offseted(source))
+            return .init(\.deletes, offset.offseted(target), offset.offseted(source))
         case .prependOrRemoveFirst where sourceCount > targetCount:
-            return .init(\.deletes, o, o.offseted(source - target))
+            return .init(\.deletes, offset, offset.offseted(source - target))
         case .reload:
             var update = BatchUpdates.Source<C>()
             let diff = source - target, minValue = min(source, target)
-            if minValue != 0 { update.add(\.reloads, o, o.offseted(minValue)) }
-            if diff > 0 { update.add(\.deletes, o.offseted(minValue), o.offseted(source)) }
+            if minValue != 0 { update.add(\.reloads, offset, offset.offseted(minValue)) }
+            if diff > 0 { update.add(\.deletes, offset.offseted(minValue), offset.offseted(source)) }
             return update
         case .appendOrRemoveLast, .prependOrRemoveFirst, .insert:
             return nil
         }
     }
-    
+
     func targetUpdate<C: UpdateIndexCollection>(
         _ way: ListKit.UpdateWay,
         _ context: UpdateContext<Offset<C.Element>> = (nil, false, []),
         _ forContainer: Bool = false
     ) -> BatchUpdates.Target<C>? {
-        let o = context.offset?.offset.target ?? .zero
+        let offset = context.offset?.offset.target ?? .zero
         let source = forContainer ? sourceCountForContainer : sourceCount
         let target = forContainer ? targetCountForContainer : targetCount
         switch way {
         case .insert:
-            return .init(\.inserts, o, o.offseted(target))
+            return .init(\.inserts, offset, offset.offseted(target))
         case .appendOrRemoveLast where targetCount > sourceCount:
-            return .init(\.inserts, o.offseted(source), o.offseted(target))
+            return .init(\.inserts, offset.offseted(source), offset.offseted(target))
         case .prependOrRemoveFirst where targetCount > sourceCount:
-            return .init(\.inserts, o, o.offseted(target - source))
+            return .init(\.inserts, offset, offset.offseted(target - source))
         case .reload:
             var update = BatchUpdates.Target<C>()
             let diff = target - source, minValue = min(source, target)
-            if minValue != 0 { update.reload(o, o.offseted(minValue)) }
-            if diff > 0 { update.add(\.inserts, o.offseted(minValue), o.offseted(target)) }
+            if minValue != 0 { update.reload(offset, offset.offseted(minValue)) }
+            if diff > 0 { update.add(\.inserts, offset.offseted(minValue), offset.offseted(target)) }
             return update
         case .appendOrRemoveLast, .prependOrRemoveFirst, .remove:
             return nil
         }
     }
-    
+
     func batchChangeFor<C: UpdateIndexCollection>(
         way: ListKit.UpdateWay,
         _ indexType: C.Type
@@ -406,13 +410,13 @@ extension ListCoordinatorUpdate {
 
 extension ListCoordinatorUpdate {
     var isSectionItems: Bool { sourceType == .sectionItems }
-    
+
     var sourceHasSection: Bool { sourceCount != 0 || !options.source.removeEmptySection }
     var targetHasSection: Bool { targetCount != 0 || !options.target.removeEmptySection }
-    
+
     var sourceCountForContainer: Int { isSectionItems ? (sourceHasSection ? 1 : 0) : sourceCount }
     var targetCountForContainer: Int { isSectionItems ? (targetHasSection ? 1 : 0) : targetCount }
-    
+
     func generateListUpdatesForItems() -> BatchUpdates? {
         if targetHasSection && !sourceHasSection {
             return .init(target: BatchUpdates.SectionTarget(\.inserts, 0), finalChange(true))
@@ -426,7 +430,7 @@ extension ListCoordinatorUpdate {
         case .none: return .none
         }
     }
-    
+
     func generateListUpdatesForSections() -> BatchUpdates? {
         switch changeType {
         case .other(let way): return batchChangeFor(way: way, IndexSet.self)
@@ -434,7 +438,7 @@ extension ListCoordinatorUpdate {
         default: return .none
         }
     }
-    
+
     func listUpdatesForSections() -> BatchUpdates {
         inferringMoves()
         return .batch(Order.allCases.compactMapContiguous { order in
@@ -448,7 +452,7 @@ extension ListCoordinatorUpdate {
             return .init(update: (source.update, target.update), change: target.change)
         })
     }
-    
+
     func listUpdatesForItems() -> BatchUpdates {
         inferringMoves()
         return .batch([Order.second, Order.third].compactMapContiguous { order in
@@ -470,26 +474,26 @@ extension ListCoordinatorUpdate {
         guard let index = context.offset?.index else { return indices }
         return indices.mapContiguous { (index, $0.isFake) }
     }
-    
+
     func toIndices<O>(_ count: Int, _ context: UpdateContext<Offset<O>>, isFake: Bool = false) -> Indices {
         .init(repeatElement: (context.offset?.index ?? 0, isFake), count: count)
     }
-    
+
     func toContext<Offset, OtherOffset>(
         _ context: UpdateContext<Offset>,
         add: (Offset) -> OtherOffset
     ) -> UpdateContext<OtherOffset> {
         return (context.offset.map(add), context.isMoved, context.ids)
     }
-    
+
     func notUpdate<O>(_ order: Order, _ context: UpdateContext<O>) -> Bool {
         order > maxOrder(context.ids)
     }
-    
+
     func hasNext<O>(_ order: Order, _ context: UpdateContext<O>) -> Bool {
         maxOrder(context.ids) > order
     }
-    
+
     func maxOrder(_ ids: [AnyHashable] = []) -> Order? {
         cachedMaxOrder.value ?? cachedMaxOrder[ids] ?? {
             let maxOrder = configMaxOrderForContext(ids)
@@ -497,7 +501,7 @@ extension ListCoordinatorUpdate {
             return maxOrder
         }()
     }
-    
+
     func moveType<O>(_ context: UpdateContext<O>) -> MoveType? { moveType(context.ids) }
     func moveType(_ ids: [AnyHashable]) -> MoveType? { moveType.value ?? moveType[ids] }
 }
@@ -526,7 +530,7 @@ extension ListCoordinatorUpdate {
             dict[id] = .some(.none)
         }
     }
-    
+
     func config<T, Value, Change: CoordinatorUpdate.Change<Value>>(
         for change: Change,
         _ key: AnyHashable,
@@ -535,7 +539,7 @@ extension ListCoordinatorUpdate {
         _ associate: ((Mapping<Change>, Mapping<[AnyHashable]>) -> Void)? = nil,
         _ toChange: (T) -> Change? = { $0 as? Change }
     ) {
-        func convert(_ change: (ids: [AnyHashable], change: T)??) ->  ([AnyHashable], Change)? {
+        func convert(_ change: (ids: [AnyHashable], change: T)??) -> ([AnyHashable], Change)? {
             change?.flatMap { change in toChange(change.change).map { (change.ids, $0) } }
         }
         guard let (sourceID, source) = convert(dict.source[key]),
@@ -559,7 +563,8 @@ extension ListCoordinatorUpdate {
             associate?((source, target), (sourceID, targetID))
         }
     }
-    
+
+    // swiftlint:disable function_parameter_count
     func configCoordinatorChange<Offset, Value, Change: CoordinatorUpdate.Change<Value>>(
         _ change: Change,
         context: UpdateContext<Offset>,
@@ -585,7 +590,8 @@ extension ListCoordinatorUpdate {
             deleteOrInsert(change)
         }
     }
-    
+    // swiftlint:enable function_parameter_count
+
     func configCoordinatorChange<Offset: ListIndex, Value>(
         _ change: Change<Value>,
         context: UpdateContext<Offset>,
@@ -604,12 +610,12 @@ extension ListCoordinatorUpdate {
             reload: { change, _ in
                 update.add(\.reloads, change.indexPath(context.ids))
             },
-            move: { change, associated, isReload in
+            move: { change, _, _ in
                 update.move(change.indexPath(context.ids))
             }
         )
     }
-    
+
     func configCoordinatorChange<O: ListIndex, Value>(
         _ change: Change<Value>,
         context: UpdateContext<Offset<O>>,

--- a/Sources/Coordinator/CoordinatorUpdate/NSCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/NSCoordinatorUpdate.swift
@@ -9,23 +9,23 @@ import Foundation
 
 final class NSCoordinatorUpdate<SourceBase: NSDataSource>: ListCoordinatorUpdate<SourceBase>
 where SourceBase.SourceBase == SourceBase {
-    
+
     weak var coordinator: NSCoordinator<SourceBase>?
     var indices: Mapping<Indices>
-    
+
     var _section: ChangeSets<IndexSet>?
     var _item: ChangeSets<IndexPathSet>?
-    
+
     override var section: ChangeSets<IndexSet> {
         get { _section.or(.init()) }
         set { _section = newValue }
     }
-    
+
     override var item: ChangeSets<IndexPathSet> {
         get { _item.or(.init()) }
         set { _item = newValue }
     }
-    
+
     init(
         coordinator: NSCoordinator<SourceBase>,
         update: ListUpdate<SourceBase>?,
@@ -38,30 +38,30 @@ where SourceBase.SourceBase == SourceBase {
         super.init(coordinator, update: update, sources: sources, options: options)
         if isBatchUpdate { target = sources.target }
     }
-    
+
     override func configSourceCount() -> Int { indices.source.count }
     override func configTargetCount() -> Int { indices.target.count }
-    
+
     override func configUpdateWay() -> UpdateWay? {
         _item != nil || _section != nil ? .batch : super.configUpdateWay()
     }
-    
+
     override func configMaxOrderForContext(_ ids: [AnyHashable]) -> Order? {
         if _item != nil && sourceType.isItems { return .second }
         if _section != nil { return .first }
         return super.configMaxOrderForContext(ids)
     }
-    
+
     override func updateData(_ isSource: Bool, containsSubupdate: Bool) {
         super.updateData(isSource, containsSubupdate: containsSubupdate)
         coordinator?.indices = indices.target
     }
-    
+
     override func customUpdateWay() -> UpdateWay? {
         if isBatchUpdate { return .batch }
         return .other(.reload)
     }
-    
+
     override func generateSourceUpdate(
         order: Order,
         context: UpdateContext<Int> = (nil, false, [])
@@ -75,7 +75,7 @@ where SourceBase.SourceBase == SourceBase {
         let item = _item?.source.offseted(by: (context.offset).map { IndexPath(section: $0) })
         return (sourceCount, .init(item: item, section: section))
     }
-    
+
     override func generateTargetUpdate(
         order: Order,
         context: UpdateContext<Offset<Int>> = (nil, false, [])
@@ -92,7 +92,7 @@ where SourceBase.SourceBase == SourceBase {
         let item = _item?.target.offseted(by: offset)
         return (toIndices(targetCount, context), .init(item: item, section: section), finalChange())
     }
-    
+
     override func generateSourceItemUpdate(
         order: Order,
         context: UpdateContext<IndexPath> = (nil, false, [])
@@ -103,7 +103,7 @@ where SourceBase.SourceBase == SourceBase {
         case .third: return (targetCount, nil)
         }
     }
-    
+
     override func generateTargetItemUpdate(
         order: Order,
         context: UpdateContext<Offset<IndexPath>> = (nil, false, [])

--- a/Sources/Coordinator/CoordinatorUpdate/SectionsCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/SectionsCoordinatorUpdate.swift
@@ -5,14 +5,15 @@
 //  Created by Frain on 2020/7/15.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
-class SectionsCoordinatorUpdate<SourceBase>:
-    ContainerCoordinatorUpdate<
-        SourceBase,
-        ContiguousArray<Sources<SourceBase.Source.Element, SourceBase.Item>>,
-        Sources<SourceBase.Source.Element, SourceBase.Item>
-    >
+class SectionsCoordinatorUpdate<SourceBase>: ContainerCoordinatorUpdate<
+    SourceBase,
+    ContiguousArray<Sources<SourceBase.Source.Element, SourceBase.Item>>,
+    Sources<SourceBase.Source.Element, SourceBase.Item>
+>
 where
     SourceBase: DataSource,
     SourceBase.SourceBase == SourceBase,
@@ -22,13 +23,13 @@ where
 {
     typealias Value = ListKit.Sources<SourceBase.Source.Element, SourceBase.Item>
     typealias Sections = ContiguousArray<Value>
-    
+
     weak var coordinator: SectionsCoordinator<SourceBase>?
-    
+
     var updateType: ItemsCoordinatorUpdate<Value>.Type { ItemsCoordinatorUpdate<Value>.self }
-    
+
     override var identifiable: Bool { false }
-    
+
     required init(
         coordinator: SectionsCoordinator<SourceBase>,
         update: ListUpdate<SourceBase>?,
@@ -40,33 +41,33 @@ where
         self.coordinator = coordinator
         super.init(coordinator, update, values, sources, indices, options)
     }
-    
+
     override func toIdentifier(_ value: Value) -> ObjectIdentifier {
         ObjectIdentifier(value.listCoordinator)
     }
-    
+
     override func toIndices(_ values: Values) -> Indices {
         SectionsCoordinator<SourceBase>.toIndices(values, options.target)
     }
-    
+
     override func subupdate(from value: Mapping<Value>) -> Subupdate {
         let (source, target) = (value.source.listCoordinator, value.target.listCoordinator)
         return target.update(from: source, updateWay: updateWay)
     }
-    
+
     override func changeWhenHasNext(values: Values, source: SourceBase.Source?, indices: Indices) {
         coordinator?.sections = values
         coordinator?.indices = indices
         coordinator?.source = source
     }
-    
+
     override func toValue(_ element: Element) -> Value { element }
     override func toChange(_ value: Value, _ index: Int) -> Change {
         let change = Change(value: value, index: index, value.listCoordinator, moveAndReloadable)
         change.coordinatorUpdate = self
         return change
     }
-    
+
     override func configChangesForDiffs() -> Changes {
         let (sourceCount, targetCount) = (sourceValues.count, targetValues.count)
         let diff = sourceCount - targetCount, minCount = min(sourceCount, targetCount)
@@ -75,31 +76,31 @@ where
         let changes = (minCount..<minCount + abs(diff)).mapContiguous { toChange(values[$0], $0) }
         return (diff > 0) ? (changes, .init()) : (.init(), changes)
     }
-    
+
     override func updateData(_ isSource: Bool, containsSubupdate: Bool) {
         super.updateData(isSource, containsSubupdate: containsSubupdate)
         coordinator?.sections = isSource ? sourceValues : targetValues
         coordinator?.indices = isSource ? sourceIndices : targetIndices
     }
-    
+
     override func inferringMoves(context: Context? = nil, ids: [AnyHashable] = []) {
         guard differ.identifier != nil else { return }
         super.inferringMoves(context: context)
     }
-    
+
     override func customUpdateWay() -> UpdateWay? {
         if isBatchUpdate { return .batch }
         guard differ?.isNone == false else { return .other(.reload) }
         return .batch
     }
-    
+
     override func generateSourceUpdate(
         order: Order,
         context: UpdateContext<Int> = (nil, false, [])
     ) -> UpdateSource<BatchUpdates.ListSource> {
         sourceUpdate(order, in: context, \.section, Subupdate.generateContianerSourceUpdate)
     }
-    
+
     override func generateTargetUpdate(
         order: Order,
         context: UpdateContext<Offset<Int>> = (nil, false, [])
@@ -108,8 +109,7 @@ where
     }
 }
 
-final class RangeReplacableSectionsCoordinatorUpdate<SourceBase>:
-    SectionsCoordinatorUpdate<SourceBase>
+final class RangeReplacableSectionsCoordinatorUpdate<SourceBase>: SectionsCoordinatorUpdate<SourceBase>
 where
     SourceBase: DataSource,
     SourceBase.SourceBase == SourceBase,
@@ -118,11 +118,11 @@ where
     SourceBase.Source.Element.Element == SourceBase.Item
 {
     override var moveAndReloadable: Bool { !noneDiffUpdate }
-    
+
     override var updateType: ItemsCoordinatorUpdate<Value>.Type {
         RangeReplacableItemsCoordinatorUpdate<Value>.self
     }
-    
+
     override func toSource(_ values: ContiguousArray<Value>) -> SourceBase.Source? {
         .init(values.map { $0.source })
     }

--- a/Sources/Coordinator/CoordinatorUpdate/WrapperCoordinatorUpdate.swift
+++ b/Sources/Coordinator/CoordinatorUpdate/WrapperCoordinatorUpdate.swift
@@ -5,16 +5,18 @@
 //  Created by Frain on 2020/8/25.
 //
 
+// swiftlint:disable shorthand_operator
+
 import Foundation
 
 final class WrapperCoordinatorUpdate<SourceBase, Other>: ListCoordinatorUpdate<SourceBase>
 where SourceBase: DataSource, SourceBase.SourceBase == SourceBase, Other: DataSource {
     typealias Wrapped = WrapperCoordinator<SourceBase, Other>.Wrapped
-    
+
     var wrappeds: Mapping<Wrapped?>
     var subupdate: ListCoordinatorUpdate<Other.SourceBase>?
     var coordinator: WrapperCoordinator<SourceBase, Other>
-    
+
     init(
         coordinator: WrapperCoordinator<SourceBase, Other>,
         update: ListUpdate<SourceBase>?,
@@ -29,31 +31,31 @@ where SourceBase: DataSource, SourceBase.SourceBase == SourceBase, Other: DataSo
         super.init(coordinator, update: update, sources: sources, options: options)
         if isBatchUpdate { self.target = source }
     }
-    
+
     override func inferringMoves(context: Context? = nil, ids: [AnyHashable] = []) {
         subupdate?.inferringMoves(context: context, ids: ids)
     }
-    
+
     override func configMaxOrderForContext(_ ids: [AnyHashable]) -> Order? {
         guard isSectionItems && targetHasSection != sourceHasSection else {
             return subupdate?.maxOrder(ids)
         }
-        
+
         switch (targetHasSection && !sourceHasSection, subupdate?.moveType(ids)) {
         case (_, .none): return .first
         case (true, .some): return .second
         case (false, .some): return .third
         }
     }
-    
+
     override func configSourceCount() -> Int { subupdate?.sourceCount ?? 0 }
     override func configTargetCount() -> Int { subupdate?.targetCount ?? 0 }
-    
+
     override func customUpdateWay() -> UpdateWay? { subupdate?.changeType }
     override func configUpdateWay() -> UpdateWay? {
         isSectionItems ? super.configUpdateWay() : subupdate?.changeType
     }
-    
+
     override func generateSourceUpdate(
         order: Order,
         context: UpdateContext<Int> = (nil, false, [])
@@ -62,7 +64,7 @@ where SourceBase: DataSource, SourceBase.SourceBase == SourceBase, Other: DataSo
         guard let subupdate = subupdate else { return (0, nil) }
         return subupdate.generateSourceUpdate(order: order, context: context)
     }
-    
+
     override func generateTargetUpdate(
         order: Order,
         context: UpdateContext<Offset<Int>> = (nil, false, [])
@@ -77,7 +79,7 @@ where SourceBase: DataSource, SourceBase.SourceBase == SourceBase, Other: DataSo
         }
         return update
     }
-    
+
     override func generateSourceItemUpdate(
         order: Order,
         context: UpdateContext<IndexPath> = (nil, false, [])
@@ -85,7 +87,7 @@ where SourceBase: DataSource, SourceBase.SourceBase == SourceBase, Other: DataSo
         guard let subupdate = subupdate else { return (0, nil) }
         return subupdate.generateSourceItemUpdate(order: order, context: context)
     }
-    
+
     override func generateTargetItemUpdate(
         order: Order,
         context: UpdateContext<Offset<IndexPath>> = (nil, false, [])
@@ -99,7 +101,7 @@ where SourceBase: DataSource, SourceBase.SourceBase == SourceBase, Other: DataSo
         }
         return update
     }
-    
+
     override func updateData(_ isSource: Bool, containsSubupdate: Bool) {
         if containsSubupdate { subupdate?.updateData(isSource, containsSubupdate: true) }
         super.updateData(isSource, containsSubupdate: containsSubupdate)

--- a/Sources/Coordinator/ItemCoordinator.swift
+++ b/Sources/Coordinator/ItemCoordinator.swift
@@ -5,16 +5,21 @@
 //  Created by Frain on 2019/10/10.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
 final class ItemCoordinator<SourceBase: DataSource>: ListCoordinator<SourceBase>
-where SourceBase.Item == SourceBase.Source, SourceBase.SourceBase == SourceBase  {
+where
+    SourceBase.Item == SourceBase.Source,
+    SourceBase.SourceBase == SourceBase
+{
     override func numbersOfSections() -> Int { 1 }
     override func numbersOfItems(in section: Int) -> Int { 1 }
-    
+
     override func item(at indexPath: IndexPath) -> Item { source }
     override func configSourceType() -> SourceType { isSectioned ? .sectionItems : .items }
-    
+
     override func update(
         from coordinator: ListCoordinator<SourceBase>,
         updateWay: ListUpdateWay<Item>?
@@ -27,7 +32,7 @@ where SourceBase.Item == SourceBase.Source, SourceBase.SourceBase == SourceBase 
             options: (coordinator.options, options)
         )
     }
-    
+
     override func update(
         update: ListUpdate<SourceBase>,
         options: ListOptions? = nil

--- a/Sources/Coordinator/ItemsCoordinator.swift
+++ b/Sources/Coordinator/ItemsCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/11/25.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
 class ItemsCoordinator<SourceBase: DataSource>: ListCoordinator<SourceBase>
@@ -14,15 +16,15 @@ where
     SourceBase.Item == SourceBase.Source.Element
 {
     lazy var items = toItems(source)
-    
+
     var updateType: ItemsCoordinatorUpdate<SourceBase>.Type {
         ItemsCoordinatorUpdate<SourceBase>.self
     }
-    
+
     func toItems(_ source: SourceBase.Source) -> ContiguousArray<Item> {
         source.mapContiguous { $0 }
     }
-    
+
     override func numbersOfItems(in section: Int) -> Int { items.count }
     override func numbersOfSections() -> Int { items.isEmpty && options.removeEmptySection ? 0 : 1 }
 
@@ -67,5 +69,3 @@ where
         RangeReplacableItemsCoordinatorUpdate<SourceBase>.self
     }
 }
-
-

--- a/Sources/Coordinator/ListCoordinatorContext.swift
+++ b/Sources/Coordinator/ListCoordinatorContext.swift
@@ -11,28 +11,28 @@ protocol CoordinatorContext: AnyObject {
     var valid: Bool { get }
     var itemCaches: ContiguousArray<ContiguousArray<Any?>> { get set }
     var itemNestedCache: ContiguousArray<ContiguousArray<((Any) -> Void)?>> { get set }
-    
+
     func isCoordinator(_ coordinator: AnyObject) -> Bool
-    
+
     func numbersOfSections() -> Int
     func numbersOfItems(in section: Int) -> Int
-    
+
     func contain(selector: Selector) -> Bool
-    
+
     func apply<Object: AnyObject, Target, Input, Output, Closure>(
         _ function: ListDelegate.Function<Object, Delegate, Target, Input, Output, Closure>,
         root: CoordinatorContext,
         object: Object,
         with input: Input
     ) -> Output?
-    
+
     func apply<Object: AnyObject, Target, Input, Output, Closure, Index: ListIndex>(
         _ function: ListDelegate.IndexFunction<Object, Delegate, Target, Input, Output, Closure, Index>,
         root: CoordinatorContext,
         object: Object,
         with input: Input
     ) -> Output?
-    
+
     func perform(updates: BatchUpdates?, animated: Bool, completion: ((ListView, Bool) -> Void)?)
 }
 
@@ -40,57 +40,57 @@ public final class ListCoordinatorContext<SourceBase: DataSource>: CoordinatorCo
 where SourceBase.SourceBase == SourceBase {
     typealias Item = SourceBase.Item
     typealias Caches<Cache> = ContiguousArray<ContiguousArray<Cache?>>
-    
+
     let listCoordinator: ListCoordinator<SourceBase>
-    
+
     var _itemCaches: Caches<Any>?
     var _itemNestedCache: Caches<((Any) -> Void)>?
-    
+
     var listDelegate = ListDelegate()
-    
+
     var index = 0
     var isSectioned = true
     var listViewGetter: (() -> ListView?)?
     var resetDelegates: (() -> Void)?
     var update: ((Int, CoordinatorUpdate) -> [(CoordinatorContext, CoordinatorUpdate)]?)?
     var contextAtIndex: ((Int, IndexPath, ListView) -> [(IndexPath, CoordinatorContext)])?
-    
+
     lazy var extraSelectors = listCoordinator.configExtraSelector(delegate: listDelegate)
         ?? listDelegate.extraSelectors
-    
+
     var listView: ListView? { listViewGetter?() }
     var valid: Bool {
         guard let storage = listCoordinator.storage else { return true }
         return !storage.isObjectAssciated || storage.object != nil
     }
-    
+
     var itemCaches: Caches<Any> {
         get { cachesOrCreate(&_itemCaches) }
         set { _itemCaches = newValue }
     }
-    
+
     var itemNestedCache: Caches<((Any) -> Void)> {
         get { cachesOrCreate(&_itemNestedCache) }
         set { _itemNestedCache = newValue }
     }
-    
+
     init(_ coordinator: ListCoordinator<SourceBase>, listDelegate: ListDelegate = .init()) {
         self.listCoordinator = coordinator
         self.listDelegate = listDelegate
         coordinator.listContexts.append(.init(context: self))
     }
-    
+
     func context(with listDelegate: ListDelegate) -> Self {
         self.listDelegate.formUnion(delegate: listDelegate)
         return self
     }
-    
+
     func isCoordinator(_ coordinator: AnyObject) -> Bool { self.listCoordinator === coordinator }
-    
+
     func reconfig() { }
     func numbersOfSections() -> Int { listCoordinator.numbersOfSections() }
     func numbersOfItems(in section: Int) -> Int { listCoordinator.numbersOfItems(in: section) }
-    
+
     // Selectors
     @discardableResult
     func apply<Object: AnyObject, Target, Input, Output, Closure>(
@@ -101,7 +101,7 @@ where SourceBase.SourceBase == SourceBase {
     ) -> Output? {
         listCoordinator.apply(function, for: self, root: root, object: object, with: input)
     }
-    
+
     @discardableResult
     func apply<Object: AnyObject, Target, Input, Output, Closure, Index: ListIndex>(
         _ function: ListDelegate.IndexFunction<Object, Delegate, Target, Input, Output, Closure, Index>,
@@ -111,17 +111,17 @@ where SourceBase.SourceBase == SourceBase {
     ) -> Output? {
         listCoordinator.apply(function, for: self, root: root, object: object, with: input, .zero)
     }
-    
+
     func contain(selector: Selector) -> Bool {
         listDelegate.contains(selector) || extraSelectors.contains(selector)
     }
-    
+
     func cachesOrCreate<Cache>(_ caches: inout Caches<Cache>?) -> Caches<Cache> {
         caches.or((0..<numbersOfSections()).mapContiguous {
             (0..<numbersOfItems(in: $0)).mapContiguous { _ in nil }
         })
     }
-    
+
     func perform(updates: BatchUpdates?, animated: Bool, completion: ((ListView, Bool) -> Void)?) {
         guard let list = listView else { return }
         guard let updates = updates else {

--- a/Sources/Coordinator/NSCoordinator.swift
+++ b/Sources/Coordinator/NSCoordinator.swift
@@ -11,7 +11,7 @@ final class NSCoordinator<SourceBase: NSDataSource>: ListCoordinator<SourceBase>
 where SourceBase.SourceBase == SourceBase {
     unowned let sourceBase: SourceBase
     lazy var indices = toIndices(source)
-    
+
     func toIndices(_ source: [Int]) -> Indices {
         if sourceType == .items {
             guard let index = source[safe: 0], index != 0 else { return [] }
@@ -19,10 +19,10 @@ where SourceBase.SourceBase == SourceBase {
         }
         if !options.removeEmptySection { return source.indices.mapContiguous { ($0, false) } }
         var indices = Indices(capacity: source.count)
-        for (i, section) in source.enumerated() where section != 0 { indices.append((i, false)) }
+        for (index, section) in source.enumerated() where section != 0 { indices.append((index, false)) }
         return indices
     }
-    
+
     override func numbersOfSections() -> Int { sourceType.isSection ? indices.count : 1 }
     override func numbersOfItems(in section: Int) -> Int {
         if sourceType == .items { return indices.count }
@@ -30,17 +30,17 @@ where SourceBase.SourceBase == SourceBase {
         if index.isFake { return 0 }
         return source[index.index]
     }
-    
+
     override func item(at indexPath: IndexPath) -> Item { sourceBase.item(at: indexPath) }
     override func configSourceType() -> SourceType {
         isSectioned || source.count > 1 ? .section : .items
     }
-    
+
     override init(_ sourceBase: SourceBase) {
         self.sourceBase = sourceBase
         super.init(sourceBase)
     }
-    
+
     override func update(
         from coordinator: ListCoordinator<SourceBase>,
         updateWay: ListUpdateWay<Item>?

--- a/Sources/Coordinator/SectionsCoordinator.swift
+++ b/Sources/Coordinator/SectionsCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/3.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
 class SectionsCoordinator<SourceBase: DataSource>: ListCoordinator<SourceBase>
@@ -15,14 +17,14 @@ where
     SourceBase.Source.Element.Element == SourceBase.Item
 {
     typealias Section = Sources<SourceBase.Source.Element, SourceBase.Item>
-    
+
     lazy var sections = toSections(source)
     lazy var indices = Self.toIndices(sections, options)
-    
+
     var updateType: SectionsCoordinatorUpdate<SourceBase>.Type {
         SectionsCoordinatorUpdate<SourceBase>.self
     }
-    
+
     func toSections(_ source: SourceBase.Source) -> ContiguousArray<Section> {
         source.mapContiguous {
             .init(
@@ -32,21 +34,21 @@ where
             )
         }
     }
-    
+
     override func item(at indexPath: IndexPath) -> Item {
         let section = sections[indices[indexPath.section].index]
         return section.listCoordinator.item(at: .init(item: indexPath.item))
     }
-    
+
     override func numbersOfSections() -> Int { indices.count }
     override func numbersOfItems(in section: Int) -> Int {
         let index = indices[section]
         if index.isFake { return 0 }
         return sections[index.index].count
     }
-    
+
     override func configSourceType() -> SourceType { .section }
-    
+
     override func update(
         from coordinator: ListCoordinator<SourceBase>,
         updateWay: ListUpdateWay<Item>?
@@ -61,7 +63,7 @@ where
             options: (coordinator.options, options)
         )
     }
-    
+
     override func update(
         update: ListUpdate<SourceBase>,
         options: ListOptions? = nil
@@ -79,9 +81,7 @@ where
     }
 }
 
-
-final class RangeReplacableSectionsCoordinator<SourceBase: DataSource>:
-    SectionsCoordinator<SourceBase>
+final class RangeReplacableSectionsCoordinator<SourceBase: DataSource>: SectionsCoordinator<SourceBase>
 where
     SourceBase.SourceBase == SourceBase,
     SourceBase.Source: RangeReplaceableCollection,
@@ -91,7 +91,7 @@ where
     override var updateType: SectionsCoordinatorUpdate<SourceBase>.Type {
         RangeReplacableSectionsCoordinatorUpdate<SourceBase>.self
     }
-    
+
     override func toSections(_ source: SourceBase.Source) -> ContiguousArray<Section> {
         source.mapContiguous {
             .init(
@@ -107,8 +107,8 @@ extension SectionsCoordinator {
     static func toIndices(_ sections: ContiguousArray<Section>, _ options: ListOptions) -> Indices {
         if !options.removeEmptySection { return sections.indices.mapContiguous { ($0, false) } }
         var indices = Indices(capacity: sections.count)
-        for (i, section) in sections.enumerated() where !section.isEmpty {
-            indices.append((i, false))
+        for (index, section) in sections.enumerated() where !section.isEmpty {
+            indices.append((index, false))
         }
         return indices
     }

--- a/Sources/Coordinator/SourcesCoordinator.swift
+++ b/Sources/Coordinator/SourcesCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/11/28.
 //
 
+// swiftlint:disable opening_brace type_body_length
+
 import Foundation
 
 struct SourceElement<Element> where Element: DataSource {
@@ -12,14 +14,14 @@ struct SourceElement<Element> where Element: DataSource {
         case items(id: Int, () -> ContiguousArray<Element>)
         case element(Element)
     }
-    
+
     let element: Subelement
     let context: ListCoordinatorContext<Element.SourceBase>
     let offset: Int
     let count: Int
-    
+
     var coordinator: ListCoordinator<Element.SourceBase> { context.listCoordinator }
-    
+
     func setting(offset: Int, count: Int? = nil) -> Self {
         .init(element: element, context: context, offset: offset, count: count ?? self.count)
     }
@@ -34,7 +36,7 @@ extension SourceElement: CustomStringConvertible, CustomDebugStringConvertible {
             return "Element(\(element))"
         }
     }
-    
+
     var debugDescription: String { description }
 }
 
@@ -48,30 +50,30 @@ where
     enum SubsourceType {
         case fromSourceBase((SourceBase.Source) -> Source, (Source) -> SourceBase.Source)
         case values
-        
+
         var from: ((SourceBase.Source) -> Source)? {
             guard case let .fromSourceBase(from, _) = self else { return nil }
             return from
         }
     }
-    
+
     typealias Subcoordinator = ListCoordinator<Source.Element.SourceBase>
     typealias Related = ListCoordinatorContext<Source.Element.SourceBase>
     typealias Subsource = SourceElement<Source.Element>
-    
+
     var subsourceType: SubsourceType
     var id = 0
-    
+
     lazy var indices = Self.toIndices(subsources)
     lazy var subsourcesAndSubsectioned = toSubsources(subsourceType.from!(source), sectioned: nil)
-    
+
     var subsources: ContiguousArray<Subsource> {
         get { subsourcesAndSubsectioned.subsources }
         set { subsourcesAndSubsectioned.subsources = newValue }
     }
-    
+
     var notItems: Bool { subsourcesAndSubsectioned.sectioned }
-    
+
     var subsourcesArray: ContiguousArray<Source.Element> {
         var sources = ContiguousArray<Source.Element>(capacity: subsources.count)
         for element in subsources {
@@ -82,11 +84,11 @@ where
         }
         return sources
     }
-    
+
     var updateType: SourcesCoordinatorUpdate<SourceBase, Source>.Type {
         SourcesCoordinatorUpdate<SourceBase, Source>.self
     }
-    
+
     init(
         _ sourceBase: SourceBase,
         toSource: @escaping (SourceBase.Source) -> (Source),
@@ -101,7 +103,7 @@ where
             options: sourceBase.listOptions
         )
     }
-    
+
     init(
         elements: ContiguousArray<Subsource>,
         update: ListUpdate<SourceBase>.Whole
@@ -111,16 +113,17 @@ where
         subsourcesAndSubsectioned = (elements, false)
         sourceType = .sectionItems
     }
-    
+
     func settingIndex(_ values: ContiguousArray<Subsource>) -> ContiguousArray<Subsource> {
         values.enumerated().forEach { $0.element.context.index = $0.offset }
         return values
     }
-    
+
     func sourceIndex<Index: ListIndex>(for listIndex: Index) -> Int {
         indices[notItems ? listIndex.section : listIndex.item].index
     }
-    
+
+    // swiftlint:disable function_body_length
     func toSubsources(
         _ source: Source,
         sectioned: Bool? = nil
@@ -129,7 +132,7 @@ where
         var (id, offset, itemOffset) = (0, 0, 0)
         var itemSources = ContiguousArray<Subsource>(capacity: source.count)
         var subsources = ContiguousArray<Subsource>(capacity: source.count)
-        
+
         func addItemSources() {
             let coordinator = SourcesCoordinator<Source.Element.SourceBase, [Source.Element]>(
                 elements: settingIndex(itemSources),
@@ -150,7 +153,7 @@ where
             itemOffset = 0
             offset += count
         }
-        
+
         for element in source {
             let context = element.listCoordinatorContext, coordinator = context.listCoordinator
             if coordinator.sourceType.isSection {
@@ -167,7 +170,7 @@ where
                 itemOffset += count
             }
         }
-        
+
         switch (sectioned, itemSources.isEmpty) {
         case (true, false):
             addItemSources()
@@ -177,10 +180,11 @@ where
         default:
             break
         }
-        
+
         return (settingIndex(subsources), sectioned)
     }
-    
+    // swiftlint:enable function_body_length
+
     func addContext(to context: ListCoordinatorContext<Source.Element.SourceBase>) {
         context.update = { [weak self] (index, subupdate) in
             guard let self = self else { return nil }
@@ -200,23 +204,23 @@ where
             update.add(subupdate: subupdate, at: index)
             return self.contextAndUpdates(update: update)
         }
-        
+
         context.contextAtIndex = { [weak self] (index, offset, listView) in
             guard let self = self else { return [] }
             let offset = offset.offseted(self.subsources[index].offset, isSection: self.notItems)
             return self.offsetAndRoot(offset: offset, list: listView)
         }
     }
-    
+
     func subContextIndex(at indexPath: IndexPath) -> (SourceElement<Source.Element>, IndexPath) {
         let index = sourceIndex(for: indexPath), context = subsources[index]
         return (context, indexPath.offseted(-context.offset, isSection: notItems))
     }
-    
+
     override func numbersOfSections() -> Int {
         notItems ? indices.count : indices.isEmpty && options.removeEmptySection ? 0 : 1
     }
-    
+
     override func numbersOfItems(in section: Int) -> Int {
         guard notItems else { return indices.count }
         let index = indices[section]
@@ -225,12 +229,12 @@ where
         let count = context.coordinator.numbersOfItems(in: section - context.offset)
         return count
     }
-    
+
     override func item(at indexPath: IndexPath) -> Item {
         let (context, indexPath) = subContextIndex(at: indexPath)
         return context.coordinator.item(at: indexPath)
     }
-    
+
     override func cache<ItemCache>(
         for cached: inout Any?,
         at indexPath: IndexPath,
@@ -240,11 +244,11 @@ where
         let (context, indexPath) = subContextIndex(at: indexPath)
         return context.coordinator.cache(for: &cached, at: indexPath, in: context.context.listDelegate)
     }
-    
+
     override func configSourceType() -> SourceType {
         subsourcesAndSubsectioned.sectioned ? .section : .items
     }
-    
+
     // Selectors
     override func configExtraSelector(delegate: ListDelegate) -> Set<Selector>? {
         guard delegate.extraSelectors.isEmpty else { return nil }
@@ -258,7 +262,7 @@ where
         }
         return results
     }
-    
+
     override func apply<Object: AnyObject, Target, Input, Output, Closure>(
         _ function: ListDelegate.Function<Object, Delegate, Target, Input, Output, Closure>,
         for context: Context,
@@ -281,7 +285,7 @@ where
             return output ?? super.apply(function, for: context, root: root, object: object, with: input)
         }
     }
-    
+
     override func apply<Object: AnyObject, Target, Input, Output, Closure, Index: ListIndex>(
         _ function: ListDelegate.IndexFunction<Object, Delegate, Target, Input, Output, Closure, Index>,
         for context: Context,
@@ -304,8 +308,7 @@ where
             return output ?? super.apply(function, for: context, root: root, object: object, with: input, offset)
         }
     }
-    
-    
+
     override func update(
         from coordinator: ListCoordinator<SourceBase>,
         updateWay: ListUpdateWay<Item>?
@@ -320,7 +323,7 @@ where
             options: (coordinator.options, options)
         )
     }
-    
+
     override func update(
         update: ListUpdate<SourceBase>,
         options: ListOptions? = nil
@@ -339,8 +342,10 @@ where
     }
 }
 
-final class DataSourcesCoordinator<SourceBase: DataSource>:
-    SourcesCoordinator<SourceBase, SourceBase.Source>
+final class DataSourcesCoordinator<SourceBase: DataSource>: SourcesCoordinator<
+    SourceBase,
+    SourceBase.Source
+>
 where
     SourceBase.SourceBase == SourceBase,
     SourceBase.Source: RangeReplaceableCollection,
@@ -350,7 +355,7 @@ where
     override var updateType: SourcesCoordinatorUpdate<SourceBase, SourceBase.Source>.Type {
         DataSourcesCoordinatorUpdate<SourceBase>.self
     }
-    
+
     init(sources sourceBase: SourceBase) {
         super.init(sourceBase, toSource: { $0 }, fromSource: { $0 })
     }

--- a/Sources/DataSource/DataSource+Coordinator/DataSource+ItemsCoordinator.swift
+++ b/Sources/DataSource/DataSource+Coordinator/DataSource+ItemsCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/17.
 //
 
+// swiftlint:disable opening_brace
+
 public extension DataSource
 where SourceBase.Source: Collection, SourceBase.Source.Element == Item {
     var listCoordinator: ListCoordinator<SourceBase> {

--- a/Sources/DataSource/DataSource+Coordinator/DataSource+SectionsCoordinator.swift
+++ b/Sources/DataSource/DataSource+Coordinator/DataSource+SectionsCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/17.
 //
 
+// swiftlint:disable opening_brace
+
 public extension DataSource
 where
     SourceBase.Source: Collection,

--- a/Sources/DataSource/DataSource+Coordinator/DataSource+SourceCoordinator.swift
+++ b/Sources/DataSource/DataSource+Coordinator/DataSource+SourceCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/17.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
 public extension DataSource

--- a/Sources/DataSource/DataSource+Coordinator/DataSource+SourcesCoordinator.swift
+++ b/Sources/DataSource/DataSource+Coordinator/DataSource+SourcesCoordinator.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/17.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
 public extension DataSource

--- a/Sources/DataSource/DataSource+ListAdapter.swift
+++ b/Sources/DataSource/DataSource+ListAdapter.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/6/10.
 //
 
+// swiftlint:disable opening_brace
+
 public extension DataSource where Self: TableListAdapter {
     var listCoordinatorContext: ListCoordinatorContext<SourceBase> {
         ListCoordinatorContext(listCoordinator, listDelegate: scrollList.listDelegate)
@@ -95,7 +97,6 @@ where
 }
 
 // MARK: - DataSource + nested Collection Adapter
-
 public extension DataSource
 where
     SourceBase.Source: CollectionListAdapter,

--- a/Sources/DataSource/DataSource+Properties.swift
+++ b/Sources/DataSource/DataSource+Properties.swift
@@ -5,13 +5,15 @@
 //  Created by Frain on 2020/2/22.
 //
 
+// swiftlint:disable opening_brace
+
 public extension DataSource {
     var listDiffer: ListDiffer<SourceBase> { .none }
     var listOptions: ListOptions { .none }
     var listUpdate: ListUpdate<SourceBase>.Whole { .reload }
 }
 
-//Equatable
+// MARK: - Equatable
 public extension DataSource where SourceBase: Equatable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
 }
@@ -20,7 +22,7 @@ public extension DataSource where SourceBase.Item: Equatable {
     var listUpdate: ListUpdate<SourceBase>.Whole { .diff }
 }
 
-//Hashable
+// MARK: - Hashable
 public extension DataSource where SourceBase: Hashable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
 }
@@ -29,7 +31,7 @@ public extension DataSource where SourceBase.Item: Hashable {
     var listUpdate: ListUpdate<SourceBase>.Whole { .diff }
 }
 
-//Identifiable
+// MARK: - Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension DataSource where SourceBase: Identifiable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
@@ -40,7 +42,7 @@ public extension DataSource where SourceBase.Item: Identifiable {
     var listUpdate: ListUpdate<SourceBase>.Whole { .diff }
 }
 
-//Identifiable + Equatable
+// MARK: - Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension DataSource where SourceBase: Identifiable, SourceBase: Equatable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
@@ -51,7 +53,7 @@ public extension DataSource where SourceBase.Item: Identifiable, SourceBase.Item
     var listUpdate: ListUpdate<SourceBase>.Whole { .diff }
 }
 
-//Identifiable + Hashable
+// MARK: - Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension DataSource where SourceBase: Identifiable, SourceBase: Hashable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
@@ -62,22 +64,22 @@ public extension DataSource where SourceBase.Item: Identifiable, SourceBase.Item
     var listUpdate: ListUpdate<SourceBase>.Whole { .diff }
 }
 
-//Object
+// MARK: - Object
 public extension DataSource where SourceBase: AnyObject {
     var listDiffer: ListDiffer<SourceBase> { .diff(id: { ObjectIdentifier($0) }) }
 }
 
-//Object + Equatable
+// MARK: - Object + Equatable
 public extension DataSource where SourceBase: AnyObject, SourceBase: Equatable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
 }
 
-//Object + Hashable
+// MARK: - Object + Hashable
 public extension DataSource where SourceBase: AnyObject, SourceBase: Hashable {
     var listDiffer: ListDiffer<SourceBase> { .diff }
 }
 
-//Subupdate
+// MARK: - Subupdate
 public extension DataSource
 where
     SourceBase.Source: DataSource,

--- a/Sources/DataSource/DataSource.swift
+++ b/Sources/DataSource/DataSource.swift
@@ -12,15 +12,15 @@ public protocol DataSource {
         where SourceBase.Item == Item, SourceBase.SourceBase == SourceBase
     associatedtype AdapterBase: DataSource = Self
         where AdapterBase.Item == Item, AdapterBase.AdapterBase == AdapterBase
-    
+
     var source: Source { get }
     var sourceBase: SourceBase { get }
     var adapterBase: AdapterBase { get }
-    
+
     var listOptions: ListOptions { get }
     var listUpdate: ListUpdate<SourceBase>.Whole { get }
     var listDiffer: ListDiffer<SourceBase> { get }
-    
+
     var listDelegate: ListDelegate { get }
     var listCoordinator: ListCoordinator<SourceBase> { get }
     var listCoordinatorContext: ListCoordinatorContext<SourceBase> { get }

--- a/Sources/DataSource/DataSourceProperties/BatchInitializable.swift
+++ b/Sources/DataSource/DataSourceProperties/BatchInitializable.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/7/24.
 //
 
+// swiftlint:disable opening_brace
+
 import Foundation
 
 public protocol BatchInitializable: ExpressibleByArrayLiteral
@@ -13,9 +15,9 @@ where ArrayLiteralElement == ListUpdate<SourceBase>.Batch {
     typealias Item = SourceBase.Item
     typealias Value = SourceBase.Item
     typealias Source = SourceBase.Source
-    
+
     var batch: ListUpdate<SourceBase>.Batch? { get }
-    
+
     init(_ batch: ListUpdate<SourceBase>.Batch)
 }
 
@@ -24,7 +26,7 @@ public extension BatchInitializable {
         let operations = elements.flatMap { $0.operations }
         self = .init(.init(operations: operations, needSource: elements.contains { $0.needSource }))
     }
-    
+
     mutating func add(_ other: ListUpdate<SourceBase>.Batch) {
         self = .init(.init(
             operations: (batch?.operations ?? []) + other.operations,
@@ -37,7 +39,7 @@ extension BatchInitializable {
     init(needSource: Bool = false, closure: @escaping (ListCoordinatorUpdate<SourceBase>) -> Void) {
         self.init(.init(operations: [closure], needSource: needSource))
     }
-    
+
     init(section: ChangeSets<IndexSet>?, item: ChangeSets<IndexPathSet>?) {
         self.init(needSource: true) { update in
             section.map { update.section = $0 }
@@ -51,32 +53,32 @@ where Source: RangeReplaceableCollection, Source.Element == SourceBase.Item {
     static func insert(_ item: Item, at index: Int) -> Self {
         .init { $0.insert(item, at: index) }
     }
-    
+
     static func insert<C: Collection>(contentsOf elements: C, at index: Int) -> Self
     where C.Element == Item {
         .init { $0.insert(contentsOf: elements, at: index) }
     }
-    
+
     static func append(_ element: Item) -> Self {
         .init { $0.append(element) }
     }
-    
+
     static func append<S: Sequence>(contentsOf items: S) -> Self where S.Element == Item {
         .init { $0.append(contentsOf: items) }
     }
-    
+
     static func remove(at index: Int) -> Self {
         .init { $0.remove(at: index) }
     }
-    
+
     static func remove(at indexSet: IndexSet) -> Self {
         .init { $0.remove(at: indexSet) }
     }
-    
+
     static func update(_ item: Item, at index: Int) -> Self {
         .init { $0.update(item, at: index) }
     }
-    
+
     static func move(at index: Int, to newIndex: Int) -> Self {
         .init { $0.move(at: index, to: newIndex) }
     }
@@ -89,7 +91,7 @@ where
     Source.Element.SourceBase.Item == SourceBase.Item
 {
     typealias Element = SourceBase.Source.Element
-    
+
     static func subsource<Subsource: UpdatableDataSource>(
         _ source: Subsource,
         update: ListUpdate<Subsource.SourceBase>,
@@ -105,36 +107,36 @@ where
             )
         }
     }
-    
+
     static func insert(_ element: Element, at index: Int) -> Self {
         .init { $0.insert(element, at: index) }
     }
-    
+
     static func insert<C: Collection>(contentsOf elements: C, at index: Int) -> Self
     where Element == C.Element {
         .init { $0.insert(contentsOf: elements, at: index) }
     }
-    
+
     static func append(_ element: Element) -> Self {
         .init { $0.append(element) }
     }
-    
+
     static func append<S: Sequence>(contentsOf elements: S) -> Self where Element == S.Element {
         .init { $0.append(contentsOf: elements) }
     }
-    
+
     static func remove(at index: Int) -> Self {
         .init { $0.remove(at: index) }
     }
-    
+
     static func remove(at indexSet: IndexSet) -> Self {
         .init { $0.remove(at: indexSet) }
     }
-    
+
     static func update(_ element: Element, at index: Int) -> Self {
         .init { $0.update(element, at: index) }
     }
-    
+
     static func move(at index: Int, to newIndex: Int) -> Self {
         .init { $0.move(at: index, to: newIndex) }
     }
@@ -144,55 +146,55 @@ public extension BatchInitializable where SourceBase: NSDataSource {
     static func insertSection(_ section: Int) -> Self {
         .init(needSource: true) { $0.section.insert(section) }
     }
-    
+
     static func insertSections(_ sections: IndexSet) -> Self {
         .init(needSource: true) { $0.section.insert(sections) }
     }
-    
+
     static func deleteSection(_ section: Int) -> Self {
         .init(needSource: true) { $0.section.delete(section) }
     }
-    
+
     static func deleteSections(_ sections: IndexSet) -> Self {
         .init(needSource: true) { $0.section.delete(sections) }
     }
-    
+
     static func reloadSection(_ section: Int, newSection: Int? = nil) -> Self {
         .init(needSource: true) { $0.section.reload(section, newIndex: newSection ?? section) }
     }
-    
+
     static func reloadSections(_ sections: IndexSet, newSections: IndexSet? = nil) -> Self {
         .init(needSource: true) { $0.section.reload(sections, newIndices: newSections ?? sections) }
     }
-    
+
     static func moveSection(_ section: Int, toSection newSection: Int) -> Self {
         .init(needSource: true) { $0.section.move(section, to: newSection) }
     }
-    
+
     static func insertItem(at indexPath: IndexPath) -> Self {
         .init(needSource: true) { $0.item.insert(indexPath) }
     }
-    
+
     static func insertItems(at indexPaths: [IndexPath]) -> Self {
         .init(needSource: true) { $0.item.insert(indexPaths) }
     }
-    
+
     static func deleteItem(at indexPath: IndexPath) -> Self {
         .init(needSource: true) { $0.item.delete(indexPath) }
     }
-    
+
     static func deleteItems(at indexPaths: [IndexPath]) -> Self {
         .init(needSource: true) { $0.item.delete(indexPaths) }
     }
-    
+
     static func reloadItem(at indexPath: IndexPath, newIndexPath: IndexPath? = nil) -> Self {
         .init(needSource: true) { $0.item.reload(indexPath, newIndex: newIndexPath ?? indexPath) }
     }
-    
+
     static func reloadItems(at indexPaths: [IndexPath], newIndexPaths: [IndexPath]? = nil) -> Self {
         .init(needSource: true) { $0.item.reload(indexPaths, newIndices: newIndexPaths ?? indexPaths) }
     }
-    
+
     static func moveItem(at indexPath: IndexPath, to newIndexPath: IndexPath) -> Self {
         .init(needSource: true) { $0.item.move(indexPath, to: newIndexPath) }
     }

--- a/Sources/DataSource/DataSourceProperties/DiffInitializable.swift
+++ b/Sources/DataSource/DataSourceProperties/DiffInitializable.swift
@@ -7,7 +7,7 @@
 
 public protocol DiffInitializable {
     associatedtype Value
-    
+
     static func diff(by areEquivalent: @escaping (Value, Value) -> Bool) -> Self
     static func diff<ID: Hashable>(id: @escaping (Value) -> ID) -> Self
     static func diff<ID: Hashable>(
@@ -16,18 +16,18 @@ public protocol DiffInitializable {
     ) -> Self
 }
 
-//Value Equatable
+// MARK: - Value Equatable
 public extension DiffInitializable where Value: Equatable {
     static var diff: Self { diff(by: ==) }
     static func diff<ID: Hashable>(id: @escaping (Value) -> ID) -> Self { diff(id: id, by: ==) }
 }
 
-//Value Hashable
+// MARK: - Value Hashable
 public extension DiffInitializable where Value: Hashable {
     static var diff: Self { diff(id: { $0 }) }
 }
 
-//Value Identifiable
+// MARK: - Value Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension DiffInitializable where Value: Identifiable {
     static var diff: Self { diff(id: \.id) }
@@ -36,13 +36,13 @@ public extension DiffInitializable where Value: Identifiable {
     }
 }
 
-//Value Identifiable + Equatable
+// MARK: - Value Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension DiffInitializable where Value: Identifiable, Value: Equatable {
     static var diff: Self { diff(id: \.id, by: ==) }
 }
 
-//Value Identifiable + Hashable
+// MARK: - Value Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension DiffInitializable where Value: Identifiable, Value: Hashable {
     static var diff: Self { diff(id: \.id, by: ==) }

--- a/Sources/DataSource/DataSourceProperties/DiffInitializableUpdate.swift
+++ b/Sources/DataSource/DataSourceProperties/DiffInitializableUpdate.swift
@@ -7,21 +7,21 @@
 
 public protocol DiffInitializableUpdate: DiffInitializable where Value == SourceBase.Item {
     associatedtype SourceBase: DataSource where SourceBase.SourceBase == SourceBase
-    
+
     init(_ whole: ListUpdate<SourceBase>.Whole)
 }
 
 public extension DiffInitializableUpdate {
     static var reload: Self { .init(.init(way: .other(.reload))) }
-    
+
     static func diff(by areEquivalent: @escaping (Value, Value) -> Bool) -> Self {
         .init(.init(id: nil, by: areEquivalent))
     }
-    
+
     static func diff<ID: Hashable>(id: @escaping (Value) -> ID) -> Self {
         .init(.init(id: id, by: nil))
     }
-    
+
     static func diff<ID: Hashable>(
         id: @escaping (Value) -> ID,
         by areEquivalent: @escaping (Value, Value) -> Bool

--- a/Sources/DataSource/DataSourceProperties/ListDiffer.swift
+++ b/Sources/DataSource/DataSourceProperties/ListDiffer.swift
@@ -12,15 +12,15 @@ public struct ListDiffer<Value>: DiffInitializable {
 
 public extension ListDiffer {
     static var none: ListDiffer<Value> { .init() }
-    
+
     static func diff(by areEquivalent: @escaping (Value, Value) -> Bool) -> Self {
         .init(areEquivalent: areEquivalent)
     }
-    
+
     static func diff<ID: Hashable>(id: @escaping (Value) -> ID) -> Self {
         .init(identifier: id)
     }
-    
+
     static func diff<ID: Hashable>(
         id: @escaping (Value) -> ID,
         by areEquivalent: @escaping (Value, Value) -> Bool
@@ -31,16 +31,16 @@ public extension ListDiffer {
 
 extension ListDiffer {
     var isNone: Bool { identifier == nil && areEquivalent == nil }
-    
+
     func hash(value: Value, into hasher: inout Hasher) {
         identifier.map { hasher.combine($0(value)) }
     }
-    
+
     func equal(lhs: Value, rhs: Value) -> Bool {
         guard let equivalent = areEquivalent else { return true }
         return equivalent(lhs, rhs)
     }
-    
+
     func diffEqual(lhs: Value, rhs: Value) -> Bool {
         switch (identifier, areEquivalent) {
         case let (id?, areEquivalent?): return id(lhs) == id(rhs) && areEquivalent(lhs, rhs)
@@ -49,7 +49,7 @@ extension ListDiffer {
         default: return false
         }
     }
-    
+
     init<OtherValue>(
         _ differ: ListDiffer<OtherValue>,
         cast: @escaping (Value) -> (OtherValue) = { $0 as! OtherValue }
@@ -57,7 +57,7 @@ extension ListDiffer {
         self.identifier = differ.identifier.map { id in { id(cast($0)) } }
         self.areEquivalent = differ.areEquivalent.map { equal in { equal(cast($0), cast($1)) } }
     }
-    
+
     init(id: AnyHashable?) {
         self.identifier = id.map { id in { _ in id } }
     }

--- a/Sources/DataSource/DataSourceProperties/ListOptions.swift
+++ b/Sources/DataSource/DataSourceProperties/ListOptions.swift
@@ -7,7 +7,7 @@
 
 public struct ListOptions: OptionSet {
     public private(set) var rawValue: Int8
-    
+
     public init(rawValue: Int8) { self.rawValue = rawValue }
 }
 

--- a/Sources/DataSource/ItemCachedDataSource.swift
+++ b/Sources/DataSource/ItemCachedDataSource.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2021/1/5.
 //
 
+// swiftlint:disable opening_brace
+
 public extension DataSource where SourceBase == Self {
     func withItemCached<ItemCache>(
         cacheForItem: @escaping (Item) -> ItemCache
@@ -15,7 +17,7 @@ public extension DataSource where SourceBase == Self {
 
 public protocol ItemCachedDataSource: DataSource {
     associatedtype ItemCache
-    
+
     var itemCached: ItemCached<SourceBase, ItemCache> { get }
 }
 
@@ -26,30 +28,30 @@ where Base.SourceBase == Base {
     public typealias Item = Base.Item
     public typealias Source = Base.Source
     public typealias SourceBase = Base.SourceBase
-    
+
     public var source: Source { sourceBase.source }
     public var sourceBase: Base
     public var listDelegate: ListDelegate
-    
+
     public var itemCached: ItemCached<Base, ItemCache> { self }
     public var listCoordinatorContext: ListCoordinatorContext<Base> {
         sourceBase.listCoordinatorContext
     }
-    
+
     public var wrappedValue: Base {
         get { sourceBase }
         set { sourceBase = newValue }
     }
-    
+
     public subscript<Value>(dynamicMember path: KeyPath<Base, Value>) -> Value {
         sourceBase[keyPath: path]
     }
-    
+
     public subscript<Value>(dynamicMember path: WritableKeyPath<Base, Value>) -> Value {
         get { sourceBase[keyPath: path] }
         set { sourceBase[keyPath: path] = newValue }
     }
-    
+
     init(_ sourceBase: Base, cacheForItem: Any? = nil) {
         var delegate = sourceBase.listDelegate
         delegate.getCache = cacheForItem

--- a/Sources/DataSource/UpdatableDataSource.swift
+++ b/Sources/DataSource/UpdatableDataSource.swift
@@ -16,14 +16,14 @@ where SourceBase.SourceBase == SourceBase {
     var coordinator: ListCoordinator<SourceBase>?
     var isObjectAssciated = false
     weak var object: AnyObject?
-    
+
     public init() { }
-    
+
     init(_ object: AnyObject) {
         self.object = object
         self.isObjectAssciated = true
     }
-    
+
     deinit {
         coordinator?.listContexts.forEach {
             $0.context?.listView?.resetDelegates(toNil: true)
@@ -33,7 +33,7 @@ where SourceBase.SourceBase == SourceBase {
 
 public extension UpdatableDataSource {
     var currentSource: SourceBase.Source { listCoordinator.source }
-    
+
     func perform(
         _ update: ListUpdate<SourceBase>,
         animated: Bool? = nil,
@@ -66,7 +66,7 @@ public extension UpdatableDataSource {
         }
         isMainThread ? afterWork() : DispatchQueue.main.sync(execute: afterWork)
     }
-    
+
     func performUpdate(
         animated: Bool? = nil,
         to source: SourceBase.Source,
@@ -78,7 +78,7 @@ public extension UpdatableDataSource {
             completion: completion
         )
     }
-    
+
     func performUpdate(animated: Bool? = nil, completion: ((ListView, Bool) -> Void)? = nil) {
         perform(.init(updateType: .whole(listUpdate)), animated: animated, completion: completion)
     }
@@ -88,11 +88,11 @@ public extension UpdatableDataSource {
     func currentItem(at indexPath: IndexPath) -> Item {
         listCoordinator.item(at: indexPath)
     }
-    
+
     func currentNumbersOfSections() -> Int {
         listCoordinator.numbersOfSections()
     }
-    
+
     func currentNumbersOfItem(in section: Int) -> Int {
         listCoordinator.numbersOfItems(in: section)
     }
@@ -128,7 +128,7 @@ extension UpdatableDataSource {
                     root: context
                 ))
             }
-            
+
             for (offset, root) in context.contextAtIndex?(context.index, .zero, listView) ?? [] {
                 results.append(.init(
                     listView: listView,

--- a/Sources/Delegate/AllSelectors.swift
+++ b/Sources/Delegate/AllSelectors.swift
@@ -5,7 +5,6 @@
 //  Created by Frain on 2019/12/13.
 //
 
-
 #if os(iOS) || os(tvOS)
 import UIKit
 
@@ -24,12 +23,12 @@ let allSelectors: Set<Selector> = {
         #selector(UIScrollViewDelegate.scrollViewDidEndZooming(_:with:atScale:)),
         #selector(UIScrollViewDelegate.scrollViewShouldScrollToTop(_:)),
         #selector(UIScrollViewDelegate.scrollViewDidScrollToTop(_:)),
-        
+
         #selector(UICollectionViewDataSource.collectionView(_:cellForItemAt:)),
         #selector(UICollectionViewDataSource.collectionView(_:viewForSupplementaryElementOfKind:at:)),
         #selector(UICollectionViewDataSource.collectionView(_:canMoveItemAt:)),
         #selector(UICollectionViewDataSource.collectionView(_:moveItemAt:to:)),
-        
+
         #selector(UICollectionViewDelegate.collectionView(_:shouldSelectItemAt:)),
         #selector(UICollectionViewDelegate.collectionView(_:didSelectItemAt:)),
         #selector(UICollectionViewDelegate.collectionView(_:shouldDeselectItemAt:)),
@@ -51,14 +50,14 @@ let allSelectors: Set<Selector> = {
         #selector(UICollectionViewDelegate.indexPathForPreferredFocusedView(in:)),
         #selector(UICollectionViewDelegate.collectionView(_:shouldUpdateFocusIn:)),
         #selector(UICollectionViewDelegate.collectionView(_:didUpdateFocusIn:with:)),
-        
+
         #selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:sizeForItemAt:)),
         #selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:insetForSectionAt:)),
         #selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:minimumLineSpacingForSectionAt:)),
         #selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:minimumInteritemSpacingForSectionAt:)),
         #selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:referenceSizeForHeaderInSection:)),
         #selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:referenceSizeForFooterInSection:)),
-        
+
         #selector(UITableViewDataSource.tableView(_:cellForRowAt:)),
         #selector(UITableViewDataSource.tableView(_:titleForHeaderInSection:)),
         #selector(UITableViewDataSource.tableView(_:titleForFooterInSection:)),
@@ -68,7 +67,7 @@ let allSelectors: Set<Selector> = {
         #selector(UITableViewDataSource.tableView(_:moveRowAt:to:)),
         #selector(UITableViewDataSource.sectionIndexTitles(for:)),
         #selector(UITableViewDataSource.tableView(_:sectionForSectionIndexTitle:at:)),
-        
+
         #selector(UITableViewDelegate.tableView(_:willDisplay:forRowAt:)),
         #selector(UITableViewDelegate.tableView(_:indentationLevelForRowAt:)),
         #selector(UITableViewDelegate.tableView(_:willSelectRowAt:)),
@@ -107,7 +106,7 @@ let allSelectors: Set<Selector> = {
         #selector(UITableViewDelegate.tableView(_:didUpdateFocusIn:with:)),
         #selector(UITableViewDelegate.indexPathForPreferredFocusedView(in:)),
     ]
-    
+
     guard #available(iOS 11.0, *) else { return selectors }
     selectors.formUnion([
         #selector(UIScrollViewDelegate.scrollViewDidChangeAdjustedContentInset(_:)),
@@ -116,8 +115,7 @@ let allSelectors: Set<Selector> = {
         #selector(UITableViewDelegate.tableView(_:leadingSwipeActionsConfigurationForRowAt:)),
         #selector(UITableViewDelegate.tableView(_:trailingSwipeActionsConfigurationForRowAt:)),
     ])
-    
-    
+
     guard #available(iOS 13.0, *) else { return selectors }
     selectors.formUnion([
         #selector(UICollectionViewDelegate.collectionView(_:shouldBeginMultipleSelectionInteractionAt:)),
@@ -135,7 +133,7 @@ let allSelectors: Set<Selector> = {
         #selector(UITableViewDelegate.tableView(_:previewForHighlightingContextMenuWithConfiguration:)),
         #selector(UITableViewDelegate.tableView(_:willPerformPreviewActionForMenuWith:animator:)),
     ])
-    
+
     return selectors
 }()
 #endif

--- a/Sources/Delegate/Delegate.swift
+++ b/Sources/Delegate/Delegate.swift
@@ -9,15 +9,15 @@ import Foundation
 
 final class Delegate: NSObject, DataSource {
     typealias Item = Never
-    
+
     unowned let listView: SetuptableListView
     var context: CoordinatorContext!
     var source: Never { fatalError() }
-    
+
     init(_ listView: SetuptableListView) {
         self.listView = listView
     }
-    
+
     func setCoordinator<SourceBase: DataSource>(
         context: ListCoordinatorContext<SourceBase>,
         update: ListUpdate<SourceBase>.Whole?,
@@ -44,7 +44,7 @@ final class Delegate: NSObject, DataSource {
         if update != nil { listView.reloadSynchronously(animated: animated) }
         completion?(true)
     }
-    
+
     func apply<Object: AnyObject, Target, Input, Output, Closure>(
         _ function: ListDelegate.Function<Object, Delegate, Target, Input, Output, Closure>,
         object: Object,
@@ -53,7 +53,7 @@ final class Delegate: NSObject, DataSource {
         guard context.valid else { return nil }
         return context.apply(function, root: context, object: object, with: input)
     }
-    
+
     func apply<Object: AnyObject, Target, Output, Closure>(
         _ function: ListDelegate.Function<Object, Delegate, Target, Void, Output, Closure>,
         object: Object
@@ -61,7 +61,7 @@ final class Delegate: NSObject, DataSource {
         guard context.valid else { return nil }
         return context.apply(function, root: context, object: object, with: ())
     }
-    
+
     func apply<Object: AnyObject, Target, Input, Output, Closure, Index: ListIndex>(
         _ function: ListDelegate.IndexFunction<Object, Delegate, Target, Input, Output, Closure, Index>,
         object: Object,
@@ -70,10 +70,9 @@ final class Delegate: NSObject, DataSource {
         guard context.valid else { return nil }
         return context.apply(function, root: context, object: object, with: input)
     }
-    
+
     override func responds(to aSelector: Selector!) -> Bool {
         guard allSelectors.contains(aSelector) else { return super.responds(to: aSelector) }
         return aSelector.map(context.contain(selector:)) == true
     }
 }
-

--- a/Sources/Delegate/ListDelegate+IndexFunction+CallAsFunction.swift
+++ b/Sources/Delegate/ListDelegate+IndexFunction+CallAsFunction.swift
@@ -23,19 +23,19 @@ public extension ListDelegate.IndexFunction where Object: UICollectionView, Inde
         identifier: String = "",
         configCell: @escaping (Cell, ListIndexContext<Object, Source, Index>, Source.Item) -> Void = { _, _, _ in }
     ) -> Target where Output == UICollectionViewCell {
-        toTarget { (context, input) in
+        toTarget { (context, _) in
             let cell = context.dequeueReusableCell(cellClass, identifier: identifier)
             configCell(cell, context, context.itemValue)
             return cell
         }
     }
-    
+
     func callAsFunction<Cell: UICollectionViewCell>(
         _ cellClass: Cell.Type,
         storyBoardIdentifier: String,
         configCell: @escaping (Cell, ListIndexContext<Object, Source, Index>, Source.Item) -> Void = { _, _, _ in }
     ) -> Target where Output == UICollectionViewCell {
-        toTarget { (context, input) in
+        toTarget { (context, _) in
             let cell = context.dequeueReusableCell(cellClass, storyBoardIdentifier: storyBoardIdentifier)
             configCell(cell, context, context.itemValue)
             return cell
@@ -47,9 +47,9 @@ public extension ListDelegate.IndexFunction where Object: UICollectionView, Inde
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> UICollectionViewCell
     ) -> Target where Output == UICollectionViewCell {
-        toTarget { context, input in closureWithCache(context, context.itemValue, context.cache()) }
+        toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction<Cell: UICollectionViewCell>(
         _ cellClass: Cell.Type,
         identifier: String = "",
@@ -61,7 +61,7 @@ public extension ListDelegate.IndexFunction where Object: UICollectionView, Inde
             return cell
         }
     }
-    
+
     func callAsFunction<Cell: UICollectionViewCell>(
         _ cellClass: Cell.Type,
         storyBoardIdentifier: String,
@@ -73,27 +73,27 @@ public extension ListDelegate.IndexFunction where Object: UICollectionView, Inde
             return cell
         }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, CollectionView.SupplementaryViewType, Source.Item, Source.ItemCache) -> UICollectionReusableView
     ) -> Target where Output == UICollectionReusableView, Input == (String, IndexPath) {
         toTarget { context, input in closureWithCache(context, .init(rawValue: input.0), context.itemValue, context.cache()) }
     }
-    
+
     @available(iOS 11.0, *)
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, UISpringLoadedInteractionContext, Source.Item, Source.ItemCache) -> Bool
     ) -> Target where Input == (IndexPath, UISpringLoadedInteractionContext), Output == Bool {
         toTarget { context, input in closureWithCache(context, input.1, context.itemValue, context.cache()) }
     }
-    
+
     @available(iOS 13.0, *)
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, CGPoint, Source.Item, Source.ItemCache) -> UIContextMenuConfiguration?
     ) -> Target where Input == (IndexPath, CGPoint), Output == UIContextMenuConfiguration? {
         toTarget { context, input in closureWithCache(context, input.1, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, UICollectionViewLayout, Source.Item, Source.ItemCache) -> CGSize
     ) -> Target where Input == (IndexPath, UICollectionViewLayout), Output == CGSize {
@@ -104,31 +104,31 @@ public extension ListDelegate.IndexFunction where Object: UICollectionView, Inde
 // MARK: - TableView Related Functions
 public extension ListDelegate.IndexFunction where Object: UITableView, Index == IndexPath {
     func callAsFunction() -> Target where Output == UITableViewCell {
-        toTarget { context, input in
+        toTarget { context, _ in
             let cell = context.dequeueReusableCell(UITableViewCell.self)
             cell.textLabel?.text = "\(context.itemValue)"
             return cell
         }
     }
-    
+
     func callAsFunction<Cell: UITableViewCell>(
         _ cellClass: Cell.Type,
         identifier: String = "",
         configCell: @escaping (Cell, ListIndexContext<Object, Source, Index>, Source.Item) -> Void = { _, _, _ in }
     ) -> Target where Output == UITableViewCell {
-        toTarget { (context, input) in
+        toTarget { (context, _) in
             let cell = context.dequeueReusableCell(cellClass, identifier: identifier)
             configCell(cell, context, context.itemValue)
             return cell
         }
     }
-    
+
     func callAsFunction<Cell: UITableViewCell>(
         _ cellClass: Cell.Type,
         storyBoardIdentifier: String,
         configCell: @escaping (Cell, ListIndexContext<Object, Source, Index>, Source.Item) -> Void = { _, _, _ in }
     ) -> Target where Output == UITableViewCell {
-        toTarget { (context, input) in
+        toTarget { (context, _) in
             let cell = context.dequeueReusableCell(cellClass, storyBoardIdentifier: storyBoardIdentifier)
             configCell(cell, context, context.itemValue)
             return cell
@@ -140,9 +140,9 @@ public extension ListDelegate.IndexFunction where Object: UITableView, Index == 
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> UITableViewCell
     ) -> Target where Output == UITableViewCell {
-        toTarget { context, input in closureWithCache(context, context.itemValue, context.cache()) }
+        toTarget { (context, _) in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction<Cell: UITableViewCell>(
         _ cellClass: Cell.Type,
         identifier: String = "",
@@ -154,7 +154,7 @@ public extension ListDelegate.IndexFunction where Object: UITableView, Index == 
             return cell
         }
     }
-    
+
     func callAsFunction<Cell: UITableViewCell>(
         _ cellClass: Cell.Type,
         storyBoardIdentifier: String,
@@ -166,69 +166,69 @@ public extension ListDelegate.IndexFunction where Object: UITableView, Index == 
             return cell
         }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, UITableViewCell.EditingStyle, Source.Item, Source.ItemCache) -> Void
     ) -> Target where Input == (UITableViewCell.EditingStyle, IndexPath), Output == Void {
         toTarget { context, input in closureWithCache(context, input.0, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, UITableViewCell, Source.Item, Source.ItemCache) -> Void
     ) -> Target where Input == (UITableViewCell, IndexPath), Output == Void {
         toTarget { context, input in closureWithCache(context, input.0, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> Int
     ) -> Target where Input == Index, Output == Int {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     @available(iOS 11.0, *)
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, UISpringLoadedInteractionContext, Source.Item, Source.ItemCache) -> Bool
     ) -> Target where Input == (IndexPath, UISpringLoadedInteractionContext), Output == Bool {
         toTarget { context, input in closureWithCache(context, input.1, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> IndexPath?
     ) -> Target where Input == Index, Output == IndexPath? {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> CGFloat
     ) -> Target where Input == Index, Output == CGFloat {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     @available(iOS 11.0, *)
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> UISwipeActionsConfiguration?
     ) -> Target where Input == Index, Output == UISwipeActionsConfiguration? {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> [UITableViewRowAction]?
     ) -> Target where Input == Index, Output == [UITableViewRowAction]? {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> UITableViewCell.EditingStyle
     ) -> Target where Input == Index, Output == UITableViewCell.EditingStyle {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, Source.Item, Source.ItemCache) -> String?
     ) -> Target where Input == Index, Output == String? {
         toTarget { context, _ in closureWithCache(context, context.itemValue, context.cache()) }
     }
-    
+
     @available(iOS 13.0, *)
     func callAsFunction(
         closureWithCache: @escaping (ListIndexContext<Object, Source, Index>, CGPoint, Source.Item, Source.ItemCache) -> UIContextMenuConfiguration

--- a/Sources/Delegate/ListDelegate.swift
+++ b/Sources/Delegate/ListDelegate.swift
@@ -19,48 +19,48 @@ public struct ListDelegate: ExpressibleByArrayLiteral {
     where Source: DataSource, Target: ScrollList<Source.AdapterBase> {
         typealias Context = ListContext<Object, Source>
         typealias ToOutput = (ListContext<Object, Source>, Input) -> Output
-        
+
         public let selector: Selector
         public var hasSectionIndex: Bool { false }
         let noOutput: Bool
         let sourceBase: Source
         let toClosure: (Closure) -> (Context, Input) -> Output
-        
+
         public func callAsFunction(closure: Closure) -> Target {
             toTarget(closure: toClosure(closure))
         }
-        
+
         public func callAsFunction(_ output: Output) -> Target where Output: FunctionOutput {
             toTarget { _, _ in output }
         }
-        
+
         func toTarget(closure: @escaping ToOutput) -> Target {
             var delegate = sourceBase.listDelegate
             delegate.functions[selector] = { closure(.init(listView: $0, context: $1, root: $2), $3) }
             return .init(sourceBase.adapterBase, listDelegate: delegate)
         }
     }
-    
+
     public struct IndexFunction<Object, Source, Target, Input, Output, Closure, Index>: ListFunction
     where Source: DataSource, Target: ScrollList<Source.AdapterBase> {
         typealias Context = ListIndexContext<Object, Source, Index>
         typealias ToOutput = (ListIndexContext<Object, Source, Index>, Input) -> Output
-        
+
         public let selector: Selector
         public let hasSectionIndex: Bool
         let noOutput: Bool
         let sourceBase: Source
         let indexForInput: (Input) -> Index
         let toClosure: (Closure) -> (Context, Input) -> Output
-        
+
         public func callAsFunction(closure: Closure) -> Target {
             toTarget(closure: toClosure(closure))
         }
-        
+
         public func callAsFunction(_ output: Output) -> Target where Output: FunctionOutput {
             toTarget { _, _ in output }
         }
-        
+
         func toTarget(getCache: Any? = nil, closure: @escaping ToOutput) -> Target {
             var delegate = sourceBase.listDelegate
             delegate.getCache = getCache ?? delegate.getCache
@@ -71,21 +71,21 @@ public struct ListDelegate: ExpressibleByArrayLiteral {
             return .init(sourceBase.adapterBase, listDelegate: delegate)
         }
     }
-    
+
     var extraSelectors = Set<Selector>()
     var functions = [Selector: Any]()
     var getCache: Any?
     var hasSectionIndex = false
-    
+
     public init(arrayLiteral elements: ListFunction...) {
         extraSelectors = .init(elements.map(\.selector))
         hasSectionIndex = elements.contains { $0.hasSectionIndex }
     }
-    
+
     func contains(_ selector: Selector) -> Bool {
         functions[selector] != nil || extraSelectors.contains(selector)
     }
-    
+
     mutating func formUnion(delegate: Self) {
         extraSelectors.formUnion(delegate.extraSelectors)
         functions.merge(delegate.functions) { _, new in new }
@@ -111,6 +111,7 @@ extension CGFloat: FunctionOutput { }
 extension UITableViewCell.EditingStyle: FunctionOutput { }
 #endif
 
+// swiftlint:disable large_tuple
 extension DataSource {
     func toClosure<Input, Output, Context>() -> (@escaping (Context) -> Output) -> (Context, Input) -> Output {
         { closure in { context, _ in closure(context) } }
@@ -123,7 +124,7 @@ extension DataSource {
     func toClosure<Input1, Input2, Output, Context>() -> (@escaping (Context, Input1, Input2) -> Output) -> (Context, (Input1, Input2)) -> Output {
         { closure in { context, input in closure(context, input.0, input.1) } }
     }
-    
+
     func toClosure<Output, Object>() -> (@escaping (ListIndexContext<Object, Self, IndexPath>, Item) -> Output) -> (ListIndexContext<Object, Self, IndexPath>, IndexPath) -> Output {
         { closure in { context, _ in closure(context, context.itemValue) } }
     }
@@ -135,25 +136,25 @@ extension DataSource {
     func toClosure<Input1, Input2, Output, Object>() -> (@escaping (ListIndexContext<Object, Self, IndexPath>, Input1, Input2, Item) -> Output) -> (ListIndexContext<Object, Self, IndexPath>, (IndexPath, Input1, Input2)) -> Output {
         { closure in { context, input in closure(context, input.1, input.2, context.itemValue) } }
     }
-    
+
     func toClosure<Input, Output, Object>() -> (@escaping (ListIndexContext<Object, Self, Int>, Input) -> Output) -> (ListIndexContext<Object, Self, Int>, (Int, Input)) -> Output {
         { closure in { context, input in closure(context, input.1) } }
     }
-    
+
     func toFunction<Object, Target, Input, Output, Closure>(
         _ selector: Selector,
         _ toClosure: @escaping (Closure) -> (ListContext<Object, Self>, Input) -> Output
     ) -> ListDelegate.Function<Object, Self, Target, Input, Output, Closure> {
         .init(selector: selector, noOutput: false, sourceBase: self, toClosure: toClosure)
     }
-    
+
     func toFunction<Object, Target, Input, Closure>(
         _ selector: Selector,
         _ toClosure: @escaping (Closure) -> (ListContext<Object, Self>, Input) -> Void
     ) -> ListDelegate.Function<Object, Self, Target, Input, Void, Closure> {
         .init(selector: selector, noOutput: true, sourceBase: self, toClosure: toClosure)
     }
-    
+
     func toFunction<Object, Target, Input, Output, Closure, Index: ListIndex>(
         _ selector: Selector,
         _ indexForInput: @escaping (Input) -> Index,
@@ -161,7 +162,7 @@ extension DataSource {
     ) -> ListDelegate.IndexFunction<Object, Self, Target, Input, Output, Closure, Index> {
         .init(selector: selector, hasSectionIndex: Index.isSection, noOutput: false, sourceBase: self, indexForInput: indexForInput, toClosure: toClosure)
     }
-    
+
     func toFunction<Object, Target, Input, Closure, Index: ListIndex>(
         _ selector: Selector,
         _ indexForInput: @escaping (Input) -> Index,
@@ -169,14 +170,14 @@ extension DataSource {
     ) -> ListDelegate.IndexFunction<Object, Self, Target, Input, Void, Closure, Index> {
         .init(selector: selector, hasSectionIndex: Index.isSection, noOutput: true, sourceBase: self, indexForInput: indexForInput, toClosure: toClosure)
     }
-    
+
     func toFunction<Object, Target, Output, Closure, Index: ListIndex>(
         _ selector: Selector,
         _ toClosure: @escaping (Closure) -> (ListIndexContext<Object, Self, Index>, Index) -> Output
     ) -> ListDelegate.IndexFunction<Object, Self, Target, Index, Output, Closure, Index> {
         .init(selector: selector, hasSectionIndex: Index.isSection, noOutput: false, sourceBase: self, indexForInput: { $0 }, toClosure: toClosure)
     }
-    
+
     func toFunction<Object, Target, Closure, Index: ListIndex>(
         _ selector: Selector,
         _ toClosure: @escaping (Closure) -> (ListIndexContext<Object, Self, Index>, Index) -> Void
@@ -184,3 +185,4 @@ extension DataSource {
         .init(selector: selector, hasSectionIndex: Index.isSection, noOutput: true, sourceBase: self, indexForInput: { $0 }, toClosure: toClosure)
     }
 }
+// swiftlint:enable large_tuple

--- a/Sources/Delegate/ListDelegates+UIKit/ListDelegates+UICollectionView.swift
+++ b/Sources/Delegate/ListDelegates+UIKit/ListDelegates+UICollectionView.swift
@@ -9,25 +9,25 @@
 import UIKit
 
 extension Delegate: UICollectionViewDataSource {
-    //Getting Item and Section Metrics
+    // MARK: - Getting Item and Section Metrics
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         context.numbersOfItems(in: section)
     }
-    
+
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         context.numbersOfSections()
     }
-    
-    //Getting Views for Items
+
+    // MARK: - Getting Views for Items
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         apply(collectionViewCellForItem, object: collectionView, with: indexPath) ?? .init()
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         apply(collectionViewSupplementaryViewForItem, object: collectionView, with: (indexPath, kind)) ?? .init()
     }
-    
-    //Reordering Items
+
+    // MARK: - Reordering Items
     func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
         apply(collectionViewCanMoveItem, object: collectionView, with: indexPath) ?? true
     }
@@ -38,7 +38,7 @@ extension Delegate: UICollectionViewDataSource {
 }
 
 extension Delegate: UICollectionViewDelegate {
-    //Managing the Selected Cells
+    // MARK: - Managing the Selected Cells
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         apply(collectionViewShouldSelectItem, object: collectionView, with: indexPath) ?? true
     }
@@ -54,23 +54,23 @@ extension Delegate: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         apply(collectionViewDidDeselectItem, object: collectionView, with: indexPath)
     }
-    
+
     @available(iOS 13.0, *)
     func collectionView(_ collectionView: UICollectionView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
         apply(collectionViewShouldBeginMultipleSelectionInteractionForItem, object: collectionView, with: indexPath) ?? true
     }
-    
+
     @available(iOS 13.0, *)
     func collectionView(_ collectionView: UICollectionView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
         apply(collectionViewDidBeginMultipleSelectionInteractionAtForItem, object: collectionView, with: indexPath)
     }
-    
+
     @available(iOS 13.0, *)
     func collectionViewDidEndMultipleSelectionInteraction(_ collectionView: UICollectionView) {
         apply(collectionViewDidEndMultipleSelectionInteraction, object: collectionView)
     }
 
-    //Managing Cell Highlighting
+    // MARK: - Managing Cell Highlighting
     func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
         apply(collectionViewShouldHighlightItem, object: collectionView, with: indexPath) ?? true
     }
@@ -83,7 +83,7 @@ extension Delegate: UICollectionViewDelegate {
         apply(collectionViewDidUnhighlightItem, object: collectionView, with: indexPath)
     }
 
-    //Tracking the Addition and Removal of Views
+    // MARK: - Tracking the Addition and Removal of Views
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         apply(collectionViewWillDisplayForItem, object: collectionView, with: (indexPath, cell))
     }
@@ -100,7 +100,7 @@ extension Delegate: UICollectionViewDelegate {
         apply(collectionViewDidEndDisplayingSupplementaryView, object: collectionView, with: (view, elementKind, indexPath))
     }
 
-    //Handling Layout Changes
+    // MARK: - Handling Layout Changes
     func collectionView(_ collectionView: UICollectionView, transitionLayoutForOldLayout fromLayout: UICollectionViewLayout, newLayout toLayout: UICollectionViewLayout) -> UICollectionViewTransitionLayout {
         apply(collectionViewTransitionLayoutForOldLayoutNewLayout, object: collectionView, with: (fromLayout, toLayout)) ?? .init(currentLayout: fromLayout, nextLayout: toLayout)
     }
@@ -113,7 +113,7 @@ extension Delegate: UICollectionViewDelegate {
         apply(collectionViewTargetIndexPathForMoveFromItem, object: collectionView, with: (originalIndexPath, proposedIndexPath)) ?? proposedIndexPath
     }
 
-    //Managing Actions for Cells
+    // MARK: - Managing Actions for Cells
     func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
         apply(collectionViewShouldShowMenuForItem, object: collectionView, with: indexPath) ?? true
     }
@@ -126,7 +126,7 @@ extension Delegate: UICollectionViewDelegate {
         apply(collectionViewPerformActionWithSender, object: collectionView, with: (indexPath, action, sender))
     }
 
-    //Managing Focus in a Collection View
+    // MARK: - Managing Focus in a Collection View
     func collectionView(_ collectionView: UICollectionView, canFocusItemAt indexPath: IndexPath) -> Bool {
         apply(collectionViewCanFocusItem, object: collectionView, with: indexPath) ?? true
     }
@@ -143,28 +143,28 @@ extension Delegate: UICollectionViewDelegate {
         apply(collectionViewDidUpdateFocusInWith, object: collectionView, with: (context, coordinator))
     }
 
-    //Controlling the Spring-Loading Behavior
+    // MARK: - Controlling the Spring-Loading Behavior
     @available(iOS 11.0, *)
     func collectionView(_ collectionView: UICollectionView, shouldSpringLoadItemAt indexPath: IndexPath, with context: UISpringLoadedInteractionContext) -> Bool {
         apply(collectionViewShouldSpringLoadItemAtWith, object: collectionView, with: (indexPath, context)) ?? true
     }
 
-    //Instance Methods
+    // MARK: - Instance Methods
     @available(iOS 13.0, *)
     func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         apply(collectionViewContextMenuConfigurationForItem, object: collectionView, with: (indexPath, point)) ?? nil
     }
-    
+
     @available(iOS 13.0, *)
     func collectionView(_ collectionView: UICollectionView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         apply(collectionViewPreviewForDismissingContextMenuWithConfiguration, object: collectionView, with: (configuration)) ?? nil
     }
-    
+
     @available(iOS 13.0, *)
     func collectionView(_ collectionView: UICollectionView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         apply(collectionViewPreviewForHighlightingContextMenuWithConfiguration, object: collectionView, with: (configuration)) ?? nil
     }
-    
+
     @available(iOS 13.0, *)
     func collectionView(_ collectionView: UICollectionView, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionCommitAnimating) {
         apply(collectionViewWillPerformPreviewActionForMenuWithAnimator, object: collectionView, with: (configuration, animator))
@@ -172,12 +172,12 @@ extension Delegate: UICollectionViewDelegate {
 }
 
 extension Delegate: UICollectionViewDelegateFlowLayout {
-    //Getting the Size of Items
+    // MARK: - Getting the Size of Items
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         apply(collectionViewLayoutSizeForItem, object: collectionView, with: (indexPath, collectionViewLayout)) ?? (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize ?? .zero
     }
 
-    //Getting the Section Spacing
+    // MARK: - Getting the Section Spacing
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         apply(collectionViewLayoutInsetForSection, object: collectionView, with: (section, collectionViewLayout)) ?? (collectionViewLayout as? UICollectionViewFlowLayout)?.sectionInset ?? .zero
     }
@@ -190,7 +190,7 @@ extension Delegate: UICollectionViewDelegateFlowLayout {
         apply(collectionViewLayoutMinimumInteritemSpacingForSection, object: collectionView, with: (section, collectionViewLayout)) ?? (collectionViewLayout as? UICollectionViewFlowLayout)?.minimumInteritemSpacing ?? .zero
     }
 
-    //Getting the Header and Footer Sizes
+    // MARK: - Getting the Header and Footer Sizes
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         apply(collectionViewLayoutReferenceSizeForHeaderInSection, object: collectionView, with: (section, collectionViewLayout)) ?? (collectionViewLayout as? UICollectionViewFlowLayout)?.headerReferenceSize ?? .zero
     }
@@ -199,6 +199,5 @@ extension Delegate: UICollectionViewDelegateFlowLayout {
         apply(collectionViewLayoutReferenceSizeForFooterInSection, object: collectionView, with: (section, collectionViewLayout)) ?? (collectionViewLayout as? UICollectionViewFlowLayout)?.footerReferenceSize ?? .zero
     }
 }
-
 
 #endif

--- a/Sources/Delegate/ListDelegates+UIKit/ListDelegates+UIScrollView.swift
+++ b/Sources/Delegate/ListDelegates+UIKit/ListDelegates+UIScrollView.swift
@@ -8,66 +8,64 @@
 #if os(iOS) || os(tvOS)
 import UIKit
 
-//MARK: - ScrollView Delegate
+// MARK: - ScrollView Delegate
 extension Delegate: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         apply(scrollViewDidScroll, object: scrollView)
     }
-    
+
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         apply(scrollViewDidZoom, object: scrollView)
     }
-    
+
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         apply(scrollViewWillBeginDragging, object: scrollView)
     }
-    
+
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         apply(scrollViewWillEndDragging, object: scrollView, with: (velocity, targetContentOffset))
     }
-    
+
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         apply(scrollViewDidEndDragging, object: scrollView, with: (decelerate))
     }
-    
+
     func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
         apply(scrollViewWillBeginDecelerating, object: scrollView)
     }
-    
+
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         apply(scrollViewDidEndDecelerating, object: scrollView)
     }
-    
+
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         apply(scrollViewDidEndScrollingAnimation, object: scrollView)
     }
-    
+
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         apply(viewForZooming, object: scrollView) ?? nil
     }
-    
+
     func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
         apply(scrollViewWillBeginZooming, object: scrollView, with: (view))
     }
-    
+
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
         apply(scrollViewDidEndZooming, object: scrollView, with: (view, scale))
     }
-    
+
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
         apply(scrollViewShouldScrollToTop, object: scrollView) ?? true
     }
-    
+
     func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
         apply(scrollViewDidScrollToTop, object: scrollView)
     }
-    
+
     @available(iOS 11.0, *)
     func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
         apply(scrollViewDidChangeAdjustedContentInset, object: scrollView)
     }
 }
 
-
 #endif
-

--- a/Sources/Delegate/ListDelegates+UIKit/ListDelegates+UITableView.swift
+++ b/Sources/Delegate/ListDelegates+UIKit/ListDelegates+UITableView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension Delegate: UITableViewDataSource {
-    //Providing the Number of Rows and Sections
+    // MARK: - Providing the Number of Rows and Sections
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         context.numbersOfItems(in: section)
     }
@@ -17,8 +17,8 @@ extension Delegate: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         context.numbersOfSections()
     }
-    
-    //Providing Cells, Headers, and Footers
+
+    // MARK: - Providing Cells, Headers, and Footers
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         apply(tableViewCellForRow, object: tableView, with: indexPath) ?? .init()
     }
@@ -31,7 +31,7 @@ extension Delegate: UITableViewDataSource {
         apply(tableViewFooterTitleForSection, object: tableView, with: section) ?? nil
     }
 
-    //Inserting or DeletingTable Rows
+    // MARK: - Inserting or DeletingTable Rows
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         apply(tableViewCommitEdittingStyleForRow, object: tableView, with: (indexPath, editingStyle))
     }
@@ -39,8 +39,8 @@ extension Delegate: UITableViewDataSource {
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         apply(tableViewCanEditRow, object: tableView, with: indexPath) ?? true
     }
-    
-    //ReorderingTable Rows
+
+    // MARK: - ReorderingTable Rows
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         apply(tableViewCanMoveRow, object: tableView, with: indexPath) ?? true
     }
@@ -49,18 +49,18 @@ extension Delegate: UITableViewDataSource {
         apply(tableViewMoveRow, object: tableView, with: (sourceIndexPath, destinationIndexPath))
     }
 
-    //Configuring an Index
+    // MARK: - Configuring an Index
     func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         apply(tableViewSectionIndexTitles, object: (tableView)) ?? nil
     }
-    
+
     func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
         apply(tableViewSectionForSectionIndexTitle, object: tableView, with: (title, index)) ?? index
     }
 }
 
 extension Delegate: UITableViewDelegate {
-    //Configuring Rows for theTable View
+    // MARK: - Configuring Rows for theTable View
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         apply(tableViewWillDisplayRow, object: tableView, with: (indexPath, cell))
     }
@@ -74,7 +74,7 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewShouldSpringLoadRow, object: tableView, with: (indexPath, context)) ?? true
     }
 
-    //Responding to Row Selections
+    // MARK: - Responding to Row Selections
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         apply(tableViewWillSelectRow, object: tableView, with: indexPath) ?? indexPath
     }
@@ -95,18 +95,18 @@ extension Delegate: UITableViewDelegate {
     func tableView(_ tableView: UITableView, shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool {
         apply(tableViewShouldBeginMultipleSelectionInteraction, object: tableView, with: indexPath) ?? true
     }
-    
+
     @available(iOS 13.0, *)
     func tableView(_ tableView: UITableView, didBeginMultipleSelectionInteractionAt indexPath: IndexPath) {
         apply(tableViewDidBeginMultipleSelectionInteraction, object: tableView, with: indexPath)
     }
-    
+
     @available(iOS 13.0, *)
     func tableViewDidEndMultipleSelectionInteraction(_ tableView: UITableView) {
         apply(tableViewDidEndMultipleSelectionInteraction, object: tableView)
     }
-    
-    //Providing Custom Header and Footer Views
+
+    // MARK: - Providing Custom Header and Footer Views
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         apply(tableViewViewHeaderForSection, object: tableView, with: section) ?? nil
     }
@@ -123,7 +123,7 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewWillDisplayFooterView, object: tableView, with: (section, view))
     }
 
-    //Providing Header, Footer, and Row Heights
+    // MARK: - Providing Header, Footer, and Row Heights
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         apply(tableViewHeightForRow, object: tableView, with: indexPath) ?? tableView.rowHeight
     }
@@ -136,7 +136,7 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewHeightForFooter, object: tableView, with: section) ?? tableView.sectionFooterHeight
     }
 
-    //Estimating Heights for theTable's Content
+    // MARK: - Estimating Heights for theTable's Content
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         apply(tableViewEstimatedHeightForRow, object: tableView, with: indexPath) ?? tableView.estimatedRowHeight
     }
@@ -149,12 +149,12 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewEstimatedHeightForFooter, object: tableView, with: section) ?? tableView.estimatedSectionFooterHeight
     }
 
-    //Managing Accessory Views
+    // MARK: - Managing Accessory Views
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
         apply(tableViewAccessoryButtonTapped, object: tableView, with: indexPath)
     }
 
-    //Responding to Row Actions
+    // MARK: - Responding to Row Actions
     @available(iOS 11.0, *)
     func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         apply(tableViewLeadingSwipeActionsConfiguration, object: tableView, with: indexPath) ?? nil
@@ -181,8 +181,8 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewEditActionsForRow, object: tableView, with: indexPath) ?? nil
     }
 
-    //ManagingTable View Highlights
-    
+    // MARK: - ManagingTable View Highlights
+
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         apply(tableViewShouldHighlight, object: tableView, with: indexPath) ?? true
     }
@@ -195,7 +195,7 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewDidUnhighlight, object: tableView, with: indexPath)
     }
 
-    //EditingTable Rows
+    // MARK: - EditingTable Rows
 
     func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath) {
         apply(tableViewWillBeginEditing, object: tableView, with: indexPath)
@@ -217,13 +217,13 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewShouldIndentWhileEditing, object: tableView, with: indexPath) ?? false
     }
 
-    //ReorderingTable Rows
+    // MARK: - ReorderingTable Rows
 
     func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         apply(tableViewTargetIndexPathForMoveFromRowAtToProposedIndexPath, object: tableView, with: (sourceIndexPath, proposedDestinationIndexPath)) ?? proposedDestinationIndexPath
     }
 
-    //Tracking the Removal of Views
+    // MARK: - Tracking the Removal of Views
     func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         apply(tableViewdidEndDisplayingForRowAt, object: tableView, with: (cell, indexPath))
     }
@@ -236,7 +236,7 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewDidEndDisplayingFooterView, object: tableView, with: (view, section))
     }
 
-    //ManagingTable View Focus
+    // MARK: - ManagingTable View Focus
     func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
         apply(tableViewCanFocusRow, object: tableView, with: indexPath) ?? true
     }
@@ -253,22 +253,22 @@ extension Delegate: UITableViewDelegate {
         apply(tableViewIndexPathForPreferredFocusedView, object: tableView) ?? nil
     }
 
-    //Instance Methods
+    // MARK: - Instance Methods
     @available(iOS 13.0, *)
     func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         apply(tableViewContextMenuConfigurationForRow, object: tableView, with: (indexPath, point))
     }
-    
+
     @available(iOS 13.0, *)
     func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         apply(tableViewPreviewForDismissingContextMenuWithConfiguration, object: tableView, with: configuration)
     }
-    
+
     @available(iOS 13.0, *)
     func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         apply(tableViewPreviewForHighlightingContextMenuWithConfiguration, object: tableView, with: (configuration))
     }
-    
+
     @available(iOS 13.0, *)
     func tableView(_ tableView: UITableView, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionCommitAnimating) {
         apply(tableViewWillPerformPreviewActionForMenuWithAnimator, object: tableView, with: (configuration, animator))

--- a/Sources/Extensions/Collection+Extension.swift
+++ b/Sources/Extensions/Collection+Extension.swift
@@ -7,39 +7,37 @@
 
 extension Collection {
     func mapContiguous<T>(_ transform: (Element) throws -> T) rethrows -> ContiguousArray<T> {
-        let n = count
-        if n == 0 { return [] }
-        
+        let count = count
+        if count == 0 { return [] }
+
         var result = ContiguousArray<T>()
-        result.reserveCapacity(n)
-        
-        var i = startIndex
-        
-        for _ in 0..<n {
-            result.append(try transform(self[i]))
-            formIndex(after: &i)
+        result.reserveCapacity(count)
+
+        var index = startIndex
+
+        for _ in 0..<count {
+            result.append(try transform(self[index]))
+            formIndex(after: &index)
         }
-        
+
         return result
     }
 
-    func compactMapContiguous<T>(
-        _ transform: (Element) throws -> T?
-    ) rethrows -> ContiguousArray<T> {
-        let n = count
-        if n == 0 { return [] }
-        
+    func compactMapContiguous<T>(_ transform: (Element) throws -> T?) rethrows -> ContiguousArray<T> {
+        let count = count
+        if count == 0 { return [] }
+
         var result = ContiguousArray<T>()
-        result.reserveCapacity(n)
-        
-        var i = startIndex
-        
-        for _ in 0..<n {
-            defer { formIndex(after: &i) }
-            guard let value = try transform(self[i]) else { continue }
+        result.reserveCapacity(count)
+
+        var index = startIndex
+
+        for _ in 0..<count {
+            defer { formIndex(after: &index) }
+            guard let value = try transform(self[index]) else { continue }
             result.append(value)
         }
-        
+
         return result
     }
 }
@@ -49,17 +47,17 @@ extension RangeReplaceableCollection {
         guard startIndex <= index, index < endIndex else { return nil }
         return self[index]
     }
-    
+
     mutating func append(repeatElement element: Element, count: Int) {
         guard count > 0 else { return }
         append(contentsOf: repeatElement(element, count: count))
     }
-    
+
     init(capacity: Int) {
         self.init()
         reserveCapacity(capacity)
     }
-    
+
     init(repeatElement element: Element, count: Int) {
         self.init(repeatElement(element, count: count))
     }

--- a/Sources/Extensions/CoreData+Extension.swift
+++ b/Sources/Extensions/CoreData+Extension.swift
@@ -13,7 +13,7 @@ public struct SectionUpdates {
     public let insert: IndexSet
     public let remove: IndexSet
     public let reload: IndexSet
-    
+
     public let allSourceChange: IndexSet
     public let allTargetChange: IndexSet
 }
@@ -23,7 +23,7 @@ public struct ItemUpdates {
     public let remove: [IndexPath]
     public let reload: [IndexPath]
     public let moves: [(from: IndexPath, to: IndexPath)]
-    
+
     public let allSourceChange: [IndexPath]
     public let allTargetChange: [IndexPath]
 }
@@ -37,49 +37,49 @@ where Item: NSFetchRequestResult {
         public var name: String { info.name }
         public var items: [Item] { info.objects as? [Item] ?? [] }
     }
-    
+
     public typealias SourceBase = ListFetchedResultsController<Item>
     public var fetchedResultController: NSFetchedResultsController<Item>
     public var listUpdate = ListUpdate<SourceBase>.Whole.reload
     public var listDiffer = ListDiffer<SourceBase>.diff
     public var listOptions = ListOptions()
     public var updateAnimated: Bool?
-    
+
     public var didChangeContent: (() -> Void)?
     public var willChangeContent: (() -> Void)?
-    
+
     public var willStartUpdate: (() -> Void)?
     public var shouldUpdate: ((SourceBase) -> Bool)?
     public var didUpdate: ((SourceBase) -> Void)?
     public var updateCompletion: ((ListView, Bool) -> Void)?
-    
+
     public var insertSection: ((SourceBase, NSFetchedResultsSectionInfo, Int) -> Void)?
     public var removeSection: ((SourceBase, Int) -> Void)?
     public var shouldReloadSection: ((SourceBase, NSFetchedResultsSectionInfo, Int) -> Bool)?
-    
+
     public var insertItem: ((SourceBase, Item, IndexPath) -> Void)?
     public var removeItem: ((SourceBase, IndexPath) -> Void)?
     public var shouldReloadItem: ((SourceBase, Item, IndexPath, IndexPath) -> Bool)?
     public var shouldMoveItem: ((SourceBase, Item, IndexPath, IndexPath) -> Bool)?
-    
+
     var update: ListUpdate<SourceBase>!
     var _section: ChangeSets<IndexSet>?
     var _item: ChangeSets<IndexPathSet>?
-    
+
     var section: ChangeSets<IndexSet> {
         get { _section ?? .init() }
         set { _section = newValue }
     }
-    
+
     var item: ChangeSets<IndexPathSet> {
         get { _item ?? .init() }
         set { _item = newValue }
     }
-    
+
     public var fetchedObjects: [Item] {
         fetchedResultController.fetchedObjects ?? []
     }
-    
+
     public var sectionInfo: [NSFetchedResultsSectionInfo] {
         fetchedResultController.sections ?? []
     }
@@ -109,18 +109,18 @@ where Item: NSFetchRequestResult {
         guard sectionNameKeyPath?.isEmpty == false else { return }
         listOptions.insert(.preferSection)
     }
-    
+
     public func performFetch() throws {
         try fetchedResultController.performFetch()
     }
-    
+
     open func controllerWillChangeContent(
         _ controller: NSFetchedResultsController<NSFetchRequestResult>
     ) {
         (_section, _item) = (nil, nil)
         willChangeContent?()
     }
-    
+
     open func controllerDidChangeContent(
         _ controller: NSFetchedResultsController<NSFetchRequestResult>
     ) {
@@ -132,12 +132,12 @@ where Item: NSFetchRequestResult {
         case (.some, nil): prepareUpdate(sets: &section)
         case (nil, nil): return
         }
-        
+
         guard shouldUpdate?(self) != false else { return }
         perform(.init(section: _section, item: _item), animated: updateAnimated, completion: updateCompletion)
         didUpdate?(self)
     }
-    
+
     open func controller(
         _ controller: NSFetchedResultsController<NSFetchRequestResult>,
         didChange sectionInfo: NSFetchedResultsSectionInfo,
@@ -151,7 +151,7 @@ where Item: NSFetchRequestResult {
         default: break
         }
     }
-    
+
     open func controller(
         _ controller: NSFetchedResultsController<NSFetchRequestResult>,
         didChange anObject: Any,
@@ -173,19 +173,19 @@ extension ListFetchedResultsController: NSDataSource {
     public func section(at section: Int) -> Section {
         .init(info: fetchedResultController.sections![section])
     }
-    
+
     public func items(at section: Int) -> [Item] {
         self.section(at: section).items
     }
-    
+
     public func item(at indexPath: IndexPath) -> Item {
         fetchedResultController.object(at: indexPath)
     }
-    
+
     public func numbersOfSections() -> Int {
         fetchedResultController.sections?.count ?? 0
     }
-    
+
     public func numbersOfItem(in section: Int) -> Int {
         self.section(at: section).count
     }
@@ -204,7 +204,7 @@ public extension ListFetchedResultsController {
             )
         }
     }
-    
+
     var sectionUpdates: SectionUpdates? {
         _section.map {
             .init(
@@ -262,7 +262,7 @@ extension ListFetchedResultsController {
         }
         update = .init(section: section, item: item)
     }
-    
+
     func prepareUpdate(sets: inout ChangeSets<IndexSet>) {
         if let shuoldReload = shouldReloadSection {
             sets.source.reloads.forEach {
@@ -279,7 +279,7 @@ extension ListFetchedResultsController {
             sets.target.inserts.forEach { insert(self, fetchedResultController.sections![$0], $0) }
         }
     }
-    
+
     func prepareUpdate(sets: inout ChangeSets<IndexPathSet>) {
         if shouldMoveItem != nil {
             sets.target.moves.elements().forEach {
@@ -298,14 +298,14 @@ extension ListFetchedResultsController {
             sets.target.inserts.elements().forEach { insert(self, item(at: $0), $0) }
         }
     }
-    
+
     func prepare(move sets: inout ChangeSets<IndexPathSet>, from: IndexPath!, to: IndexPath) {
         guard shouldMoveItem?(self, item(at: to), from, to) == false else { return }
         sets.target.moves.remove(to)
         sets.source.moves.remove(from)
         sets.target.moveDict[to] = nil
     }
-    
+
     func prepare(reload sets: inout ChangeSets<IndexPathSet>, from: IndexPath, to: IndexPath!) {
         guard shouldReloadItem?(self, item(at: to), from, to) == false else { return }
         sets.source.reloads.remove(from)

--- a/Sources/Extensions/IndexSet+Extension.swift
+++ b/Sources/Extensions/IndexSet+Extension.swift
@@ -14,15 +14,15 @@ extension IndexSet: UpdateIndexCollection {
     static func move(_ element: Mapping<Int>, by list: ListView) {
         list.moveSection(element.source, toSection: element.target)
     }
-    
+
     var elements: IndexSet { self }
     init(_ element: Int) { self.init(integer: element) }
     init(_ from: Int, _ to: Int) { self.init(integersIn: from..<to) }
-    
+
     mutating func add(_ other: IndexSet) { formUnion(other) }
     mutating func add(_ element: Int) { insert(element) }
     mutating func add(_ from: Int, _ to: Int) { insert(integersIn: from..<to) }
-    
+
     func elements(_ offset: Int?) -> IndexSet {
         guard let offset = offset else { return self }
         return .init(map { $0 + offset })

--- a/Sources/Extensions/Optional+Extension.swift
+++ b/Sources/Extensions/Optional+Extension.swift
@@ -9,19 +9,19 @@ extension Optional: DataSource where Wrapped: DataSource {
     public typealias Item = Wrapped.Item
     public typealias Source = Self
     public typealias SourceBase = Self
-    
+
     public var source: Source { self }
-    
+
     public var listDiffer: ListDiffer<SourceBase> {
         (source?.listDiffer).map { .init($0) } ?? .none
     }
-    
+
     public var listUpdate: ListUpdate<SourceBase>.Whole {
         (source?.listUpdate).map { .init(way: $0.way) } ?? .reload
     }
-    
+
     public var listOptions: ListOptions { source?.listOptions ?? .none }
-    
+
     public var listCoordinator: ListCoordinator<SourceBase> {
         WrapperCoordinator(self, toItem: { $0 }, toOther: { $0 })
     }

--- a/Sources/ListAdapter/CollectionListAdapter.swift
+++ b/Sources/ListAdapter/CollectionListAdapter.swift
@@ -37,7 +37,7 @@ public extension CollectionListAdapter {
         )
         return collectionList
     }
-    
+
     @discardableResult
     func apply(
         by collectionView: CollectionView,

--- a/Sources/ListAdapter/ListAdapter+FunctionBuilder/AnyCollectionSourcesBuilder.swift
+++ b/Sources/ListAdapter/ListAdapter+FunctionBuilder/AnyCollectionSourcesBuilder.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/11.
 //
 
+// swiftlint:disable line_length function_parameter_count
+
 public typealias AnyCollectionSources = CollectionList<AnySources>
 
 public extension CollectionList where Source == AnySources {
@@ -28,7 +30,7 @@ public struct AnyCollectionSourcesBuilder {
     where TrueContent: CollectionListAdapter, FalseContent: CollectionListAdapter {
         .trueContent(first)
     }
-    
+
     public static func buildEither<TrueContent, FalseContent>(
         second: FalseContent
     ) -> ConditionalSources<TrueContent, FalseContent>
@@ -39,39 +41,39 @@ public struct AnyCollectionSourcesBuilder {
     public static func buildBlock<S: CollectionListAdapter>(_ content: S) -> S {
         content
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter>(_ s0: S0, _ s1: S1) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter, S4: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3), AnyCollectionSources(s4)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter, S4: CollectionListAdapter, S5: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3), AnyCollectionSources(s4), AnyCollectionSources(s5)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter, S4: CollectionListAdapter, S5: CollectionListAdapter, S6: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3), AnyCollectionSources(s4), AnyCollectionSources(s5), AnyCollectionSources(s6)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter, S4: CollectionListAdapter, S5: CollectionListAdapter, S6: CollectionListAdapter, S7: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3), AnyCollectionSources(s4), AnyCollectionSources(s5), AnyCollectionSources(s6), AnyCollectionSources(s7)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter, S4: CollectionListAdapter, S5: CollectionListAdapter, S6: CollectionListAdapter, S7: CollectionListAdapter, S8: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7, _ s8: S8) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3), AnyCollectionSources(s4), AnyCollectionSources(s5), AnyCollectionSources(s6), AnyCollectionSources(s7), AnyCollectionSources(s8)]))
     }
-    
+
     public static func buildBlock<S0: CollectionListAdapter, S1: CollectionListAdapter, S2: CollectionListAdapter, S3: CollectionListAdapter, S4: CollectionListAdapter, S5: CollectionListAdapter, S6: CollectionListAdapter, S7: CollectionListAdapter, S8: CollectionListAdapter, S9: CollectionListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7, _ s8: S8, _ s9: S9) -> CollectionList<Sources<[AnyCollectionSources], Any>> {
         CollectionList(Sources(dataSources: [AnyCollectionSources(s0), AnyCollectionSources(s1), AnyCollectionSources(s2), AnyCollectionSources(s3), AnyCollectionSources(s4), AnyCollectionSources(s5), AnyCollectionSources(s6), AnyCollectionSources(s7), AnyCollectionSources(s8), AnyCollectionSources(s9)]))
     }

--- a/Sources/ListAdapter/ListAdapter+FunctionBuilder/AnyTableSourcesBuilder.swift
+++ b/Sources/ListAdapter/ListAdapter+FunctionBuilder/AnyTableSourcesBuilder.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/11.
 //
 
+// swiftlint:disable line_length function_parameter_count
+
 public typealias AnyTableSources = TableList<AnySources>
 
 public extension TableList where Source == AnySources {
@@ -21,14 +23,14 @@ public struct AnyTableSourcesBuilder {
     public static func buildIf<S: TableListAdapter>(_ content: S?) -> S? {
         content
     }
-    
+
     public static func buildEither<TrueContent, FalseContent>(
         first: TrueContent
     ) -> ConditionalSources<TrueContent, FalseContent>
     where TrueContent: TableListAdapter, FalseContent: TableListAdapter {
         .trueContent(first)
     }
-    
+
     public static func buildEither<TrueContent, FalseContent>(
         second: FalseContent
     ) -> ConditionalSources<TrueContent, FalseContent>
@@ -39,39 +41,39 @@ public struct AnyTableSourcesBuilder {
     public static func buildBlock<S: TableListAdapter>(_ content: S) -> S {
         content
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter>(_ s0: S0, _ s1: S1) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter, S4: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3), AnyTableSources(s4)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter, S4: TableListAdapter, S5: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3), AnyTableSources(s4), AnyTableSources(s5)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter, S4: TableListAdapter, S5: TableListAdapter, S6: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3), AnyTableSources(s4), AnyTableSources(s5), AnyTableSources(s6)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter, S4: TableListAdapter, S5: TableListAdapter, S6: TableListAdapter, S7: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3), AnyTableSources(s4), AnyTableSources(s5), AnyTableSources(s6), AnyTableSources(s7)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter, S4: TableListAdapter, S5: TableListAdapter, S6: TableListAdapter, S7: TableListAdapter, S8: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7, _ s8: S8) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3), AnyTableSources(s4), AnyTableSources(s5), AnyTableSources(s6), AnyTableSources(s7), AnyTableSources(s8)]))
     }
-    
+
     public static func buildBlock<S0: TableListAdapter, S1: TableListAdapter, S2: TableListAdapter, S3: TableListAdapter, S4: TableListAdapter, S5: TableListAdapter, S6: TableListAdapter, S7: TableListAdapter, S8: TableListAdapter, S9: TableListAdapter>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7, _ s8: S8, _ s9: S9) -> TableList<Sources<[AnyTableSources], Any>> {
         TableList(Sources(dataSources: [AnyTableSources(s0), AnyTableSources(s1), AnyTableSources(s2), AnyTableSources(s3), AnyTableSources(s4), AnyTableSources(s5), AnyTableSources(s6), AnyTableSources(s7), AnyTableSources(s8), AnyTableSources(s9)]))
     }

--- a/Sources/ListAdapter/ListAdapter+UIKit/CollectionListAdapter+UIKit.swift
+++ b/Sources/ListAdapter/ListAdapter+UIKit/CollectionListAdapter+UIKit.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/10.
 //
 
+// swiftlint:disable identifier_name large_tuple line_length
+
 #if os(iOS) || os(tvOS)
 import UIKit
 
@@ -12,193 +14,193 @@ public extension DataSource {
     typealias CollectionContext = ListContext<UICollectionView, Self>
     typealias CollectionItemContext = ListIndexContext<UICollectionView, Self, IndexPath>
     typealias CollectionSectionContext = ListIndexContext<UICollectionView, Self, Int>
-    
+
     typealias CollectionFunction<Input, Output, Closure> = ListDelegate.Function<UICollectionView, Self, CollectionList<AdapterBase>, Input, Output, Closure>
     typealias CollectionItemFunction<Input, Output, Closure> = ListDelegate.IndexFunction<UICollectionView, Self, CollectionList<AdapterBase>, Input, Output, Closure, IndexPath>
     typealias CollectionSectionFunction<Input, Output, Closure> = ListDelegate.IndexFunction<UICollectionView, Self, CollectionList<AdapterBase>, Input, Output, Closure, Int>
 }
 
-//Collection View Data Source
+// MARK: - Collection View Data Source
 public extension DataSource {
-    //Getting Views for Items
+    // MARK: - Getting Views for Items
     var collectionViewCellForItem: CollectionItemFunction<IndexPath, UICollectionViewCell, (CollectionItemContext, Item) -> UICollectionViewCell> {
         toFunction(#selector(UICollectionViewDataSource.collectionView(_:cellForItemAt:)), toClosure())
     }
-    
+
     var collectionViewSupplementaryViewForItem: CollectionItemFunction<(IndexPath, String), UICollectionReusableView, (CollectionItemContext, CollectionView.SupplementaryViewType) -> UICollectionReusableView> {
         toFunction(#selector(UICollectionViewDataSource.collectionView(_:viewForSupplementaryElementOfKind:at:)), \.0) { closure in { context, input in closure(context, .init(rawValue: input.1)) } }
     }
 
-    //Reordering Items
+    // MARK: - Reordering Items
     var collectionViewCanMoveItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDataSource.collectionView(_:canMoveItemAt:)), toClosure())
     }
-    
+
     var collectionViewMoveItem: CollectionFunction<(IndexPath, IndexPath), Void, (CollectionContext, IndexPath, IndexPath) -> Void> {
         toFunction(#selector(UICollectionViewDataSource.collectionView(_:moveItemAt:to:)), toClosure())
     }
 }
 
-//Collection View Delegate
+// MARK: - Collection View Delegate
 public extension DataSource {
-    //Managing the Selected Cells
+    // MARK: - Managing the Selected Cells
     var collectionViewShouldSelectItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldSelectItemAt:)), toClosure())
     }
-    
+
     var collectionViewDidSelectItem: CollectionItemFunction<IndexPath, Void, (CollectionItemContext, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didSelectItemAt:)), toClosure())
     }
-    
+
     var collectionViewShouldDeselectItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldDeselectItemAt:)), toClosure())
     }
-    
+
     var collectionViewDidDeselectItem: CollectionItemFunction<IndexPath, Void, (CollectionItemContext, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didDeselectItemAt:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var collectionViewShouldBeginMultipleSelectionInteractionForItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldBeginMultipleSelectionInteractionAt:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var collectionViewDidBeginMultipleSelectionInteractionAtForItem: CollectionItemFunction<IndexPath, Void, (CollectionItemContext, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didBeginMultipleSelectionInteractionAt:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var collectionViewDidEndMultipleSelectionInteraction: CollectionFunction<Void, Void, (CollectionContext) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionViewDidEndMultipleSelectionInteraction(_:)), toClosure())
     }
-    
-    //Managing Cell Highlighting
+
+    // MARK: - Managing Cell Highlighting
     var collectionViewShouldHighlightItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldHighlightItemAt:)), toClosure())
     }
-    
+
     var collectionViewDidHighlightItem: CollectionItemFunction<IndexPath, Void, (CollectionItemContext, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didHighlightItemAt:)), toClosure())
     }
-    
+
     var collectionViewDidUnhighlightItem: CollectionItemFunction<IndexPath, Void, (CollectionItemContext, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didUnhighlightItemAt:)), toClosure())
     }
-    
-    //Tracking the Addition and Removal of Views
+
+    // MARK: - Tracking the Addition and Removal of Views
     var collectionViewWillDisplayForItem: CollectionItemFunction<(IndexPath, UICollectionViewCell), Void, (CollectionItemContext, UICollectionViewCell, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:willDisplay:forItemAt:)), \.0, toClosure())
     }
-    
+
     var collectionViewWillDisplaySupplementaryView: CollectionItemFunction<(IndexPath, UICollectionReusableView, String), Void, (CollectionItemContext, UICollectionReusableView, CollectionView.SupplementaryViewType, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:willDisplaySupplementaryView:forElementKind:at:)), \.0) { closure in { context, input in closure(context, input.1, .init(rawValue: input.2), context.itemValue) } }
     }
-    
+
     var collectionViewDidEndDisplayingItem: CollectionFunction<(IndexPath, UICollectionViewCell), Void, (CollectionContext, IndexPath, UICollectionViewCell) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplaying:forItemAt:)), toClosure())
     }
-    
+
     var collectionViewDidEndDisplayingSupplementaryView: CollectionFunction<(UICollectionReusableView, String, IndexPath), Void, (CollectionContext, UICollectionReusableView, CollectionView.SupplementaryViewType, IndexPath) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:))) { closure in { context, input in closure(context, input.0, .init(rawValue: input.1), input.2) } }
     }
-    
-    //Handling Layout Changes
+
+    // MARK: - Handling Layout Changes
     var collectionViewTransitionLayoutForOldLayoutNewLayout: CollectionFunction<(UICollectionViewLayout, UICollectionViewLayout), UICollectionViewTransitionLayout, (CollectionContext, UICollectionViewLayout, UICollectionViewLayout) -> UICollectionViewTransitionLayout> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:transitionLayoutForOldLayout:newLayout:)), toClosure())
     }
-    
+
     var collectionViewTargetContentOffset: CollectionFunction<CGPoint, CGPoint, (CollectionContext, CGPoint) -> CGPoint> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:targetContentOffsetForProposedContentOffset:)), toClosure())
     }
-    
+
     var collectionViewTargetIndexPathForMoveFromItem: CollectionFunction<(IndexPath, IndexPath), IndexPath, (CollectionContext, IndexPath, IndexPath) -> IndexPath> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:targetIndexPathForMoveFromItemAt:toProposedIndexPath:)), toClosure())
     }
-    
-    //Managing Actions for Cells
+
+    // MARK: - Managing Actions for Cells
     var collectionViewShouldShowMenuForItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldShowMenuForItemAt:)), toClosure())
     }
-    
+
     var collectionViewCanPerformActionWithSender: CollectionItemFunction<(IndexPath, Selector, Any?), Bool, (CollectionItemContext, Selector, Any?, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:canPerformAction:forItemAt:withSender:)), \.0, toClosure())
     }
-    
+
     var collectionViewPerformActionWithSender: CollectionItemFunction<(IndexPath, Selector, Any?), Void, (CollectionItemContext, Selector, Any?, Item) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:performAction:forItemAt:withSender:)), \.0, toClosure())
     }
-    
-    //Managing Focus in a Collection View
+
+    // MARK: - Managing Focus in a Collection View
     var collectionViewCanFocusItem: CollectionItemFunction<IndexPath, Bool, (CollectionItemContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:canFocusItemAt:)), toClosure())
     }
-    
+
     var collectionViewIndexPathForPreferredFocusedView: CollectionFunction<Void, IndexPath?, (CollectionContext) -> IndexPath?> {
         toFunction(#selector(UICollectionViewDelegate.indexPathForPreferredFocusedView(in:)), toClosure())
     }
-    
+
     var collectionViewShouldUpdateFocusIn: CollectionFunction<UICollectionViewFocusUpdateContext, Bool, (CollectionContext, UICollectionViewFocusUpdateContext) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldUpdateFocusIn:)), toClosure())
     }
-    
+
     var collectionViewDidUpdateFocusInWith: CollectionFunction<(UICollectionViewFocusUpdateContext, UIFocusAnimationCoordinator), Void, (CollectionContext, UICollectionViewFocusUpdateContext, UIFocusAnimationCoordinator) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:didUpdateFocusIn:with:)), toClosure())
     }
 
-    //Controlling the Spring-Loading Behavior
+    // MARK: - Controlling the Spring-Loading Behavior
     @available(iOS 11.0, *)
     var collectionViewShouldSpringLoadItemAtWith: CollectionItemFunction<(IndexPath, UISpringLoadedInteractionContext), Bool, (CollectionItemContext, UISpringLoadedInteractionContext, Item) -> Bool> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:shouldSpringLoadItemAt:with:)), \.0, toClosure())
     }
-    
-    //Instance Methods
+
+    // MARK: - Instance Methods
     @available(iOS 13.0, *)
     var collectionViewContextMenuConfigurationForItem: CollectionItemFunction<(IndexPath, CGPoint), UIContextMenuConfiguration?, (CollectionItemContext, CGPoint, Item) -> UIContextMenuConfiguration> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:contextMenuConfigurationForItemAt:point:)), \.0, toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var collectionViewPreviewForDismissingContextMenuWithConfiguration: CollectionFunction<UIContextMenuConfiguration, UITargetedPreview, (CollectionContext, UIContextMenuConfiguration) -> UITargetedPreview> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:previewForDismissingContextMenuWithConfiguration:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var collectionViewPreviewForHighlightingContextMenuWithConfiguration: CollectionFunction<UIContextMenuConfiguration, UITargetedPreview, (CollectionContext, UIContextMenuConfiguration) -> UITargetedPreview> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:previewForHighlightingContextMenuWithConfiguration:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var collectionViewWillPerformPreviewActionForMenuWithAnimator: CollectionFunction<(UIContextMenuConfiguration, UIContextMenuInteractionCommitAnimating), Void, (CollectionContext, UIContextMenuConfiguration, UIContextMenuInteractionCommitAnimating) -> Void> {
         toFunction(#selector(UICollectionViewDelegate.collectionView(_:willPerformPreviewActionForMenuWith:animator:)), toClosure())
     }
 }
 
-//Collection View Delegate Flow Layout
+// MARK: - Collection View Delegate Flow Layout
 public extension DataSource {
-    //Getting the Size of Items
+    // MARK: - Getting the Size of Items
     var collectionViewLayoutSizeForItem: CollectionItemFunction<(IndexPath, UICollectionViewLayout), CGSize, (CollectionItemContext, UICollectionViewLayout, Item) -> CGSize> {
         toFunction(#selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:sizeForItemAt:)), \.0, toClosure())
     }
-    
-    //Getting the Section Spacing
+
+    // MARK: - Getting the Section Spacing
     var collectionViewLayoutInsetForSection: CollectionSectionFunction<(Int, UICollectionViewLayout), UIEdgeInsets, (CollectionSectionContext, UICollectionViewLayout) -> UIEdgeInsets> {
         toFunction(#selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:insetForSectionAt:)), \.0, toClosure())
     }
-    
+
     var collectionViewLayoutMinimumLineSpacingForSection: CollectionSectionFunction<(Int, UICollectionViewLayout), CGFloat, (CollectionSectionContext, UICollectionViewLayout) -> CGFloat> {
         toFunction(#selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:minimumLineSpacingForSectionAt:)), \.0, toClosure())
     }
-    
+
     var collectionViewLayoutMinimumInteritemSpacingForSection: CollectionSectionFunction<(Int, UICollectionViewLayout), CGFloat, (CollectionSectionContext, UICollectionViewLayout) -> CGFloat> {
         toFunction(#selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:minimumInteritemSpacingForSectionAt:)), \.0, toClosure())
     }
-    
-    //Getting the Header and Footer Sizes
+
+    // MARK: - yGetting the Header and Footer Sizes
     var collectionViewLayoutReferenceSizeForHeaderInSection: CollectionSectionFunction<(Int, UICollectionViewLayout), CGSize, (CollectionSectionContext, UICollectionViewLayout) -> CGSize> {
         toFunction(#selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:referenceSizeForHeaderInSection:)), \.0, toClosure())
     }
-    
+
     var collectionViewLayoutReferenceSizeForFooterInSection: CollectionSectionFunction<(Int, UICollectionViewLayout), CGSize, (CollectionSectionContext, UICollectionViewLayout) -> CGSize> {
         toFunction(#selector(UICollectionViewDelegateFlowLayout.collectionView(_:layout:referenceSizeForFooterInSection:)), \.0, toClosure())
     }

--- a/Sources/ListAdapter/ListAdapter+UIKit/SrcollListAdapter+UIKit.swift
+++ b/Sources/ListAdapter/ListAdapter+UIKit/SrcollListAdapter+UIKit.swift
@@ -11,59 +11,59 @@ import UIKit
 public extension DataSource {
     typealias ScrollContext = ListContext<UIScrollView, Self>
     typealias ScrollFunction<Input, Output, Closure> = ListDelegate.Function<UIScrollView, Self, ScrollList<AdapterBase>, Input, Output, Closure>
-    
+
     var scrollViewDidScroll: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidScroll), toClosure())
     }
-    
+
     var scrollViewDidZoom: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidZoom), toClosure())
     }
-    
+
     var scrollViewWillBeginDragging: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewWillBeginDragging), toClosure())
     }
-    
+
     var scrollViewWillEndDragging: ScrollFunction<(CGPoint, UnsafeMutablePointer<CGPoint>), Void, (ScrollContext, CGPoint, UnsafeMutablePointer<CGPoint>) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewWillEndDragging), toClosure())
     }
-    
+
     var scrollViewDidEndDragging: ScrollFunction<Bool, Void, (ScrollContext, Bool) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidEndDragging), toClosure())
     }
-    
+
     var scrollViewWillBeginDecelerating: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewWillBeginDecelerating), toClosure())
     }
-    
+
     var scrollViewDidEndDecelerating: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidEndDecelerating), toClosure())
     }
-    
+
     var scrollViewDidEndScrollingAnimation: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidEndScrollingAnimation), toClosure())
     }
-    
+
     var viewForZooming: ScrollFunction<Void, UIView?, (ScrollContext) -> UIView?> {
         toFunction(#selector(UIScrollViewDelegate.viewForZooming), toClosure())
     }
-    
+
     var scrollViewWillBeginZooming: ScrollFunction<UIView?, Void, (ScrollContext, UIView?) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewWillBeginZooming), toClosure())
     }
-    
+
     var scrollViewDidEndZooming: ScrollFunction<(UIView?, CGFloat), Void, (ScrollContext, UIView?, CGFloat) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidEndZooming), toClosure())
     }
-    
+
     var scrollViewShouldScrollToTop: ScrollFunction<Void, Bool, (ScrollContext) -> Bool> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewShouldScrollToTop), toClosure())
     }
-    
+
     var scrollViewDidScrollToTop: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidScrollToTop), toClosure())
     }
-    
+
     @available(iOS 11.0, *)
     var scrollViewDidChangeAdjustedContentInset: ScrollFunction<Void, Void, (ScrollContext) -> Void> {
         toFunction(#selector(UIScrollViewDelegate.scrollViewDidChangeAdjustedContentInset), toClosure())

--- a/Sources/ListAdapter/ListAdapter+UIKit/TableListAdapter+UIKit.swift
+++ b/Sources/ListAdapter/ListAdapter+UIKit/TableListAdapter+UIKit.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/10.
 //
 
+// swiftlint:disable identifier_name large_tuple
+
 #if os(iOS) || os(tvOS)
 import UIKit
 
@@ -12,258 +14,258 @@ public extension DataSource {
     typealias TableContext = ListContext<UITableView, Self>
     typealias TableItemContext = ListIndexContext<UITableView, Self, IndexPath>
     typealias TableSectionContext = ListIndexContext<UITableView, Self, Int>
-    
+
     typealias TableFunction<Input, Output, Closure> = ListDelegate.Function<UITableView, Self, TableList<AdapterBase>, Input, Output, Closure>
     typealias TableItemFunction<Input, Output, Closure> = ListDelegate.IndexFunction<UITableView, Self, TableList<AdapterBase>, Input, Output, Closure, IndexPath>
     typealias TableSectionFunction<Input, Output, Closure> = ListDelegate.IndexFunction<UITableView, Self, TableList<AdapterBase>, Input, Output, Closure, Int>
 }
 
-//TableView DataSource
+// MARK: - TableView DataSource
 public extension DataSource {
-    //Providing Cells, Headers, and Footers
+    // MARK: - Providing Cells, Headers, and Footers
     var tableViewCellForRow: TableItemFunction<IndexPath, UITableViewCell, (TableItemContext, Item) -> UITableViewCell> {
         toFunction(#selector(UITableViewDataSource.tableView(_:cellForRowAt:)), toClosure())
     }
-    
+
     var tableViewHeaderTitleForSection: TableSectionFunction<Int, String?, (TableSectionContext) -> String?> {
         toFunction(#selector(UITableViewDataSource.tableView(_:titleForHeaderInSection:)), toClosure())
     }
-    
+
     var tableViewFooterTitleForSection: TableSectionFunction<Int, String?, (TableSectionContext) -> String?> {
         toFunction(#selector(UITableViewDataSource.tableView(_:titleForFooterInSection:)), toClosure())
     }
-    
-    //Inserting or Deleting Table Rows
+
+    // MARK: - Inserting or Deleting Table Rows
     var tableViewCommitEdittingStyleForRow: TableItemFunction<(IndexPath, UITableViewCell.EditingStyle), Void, (TableItemContext, UITableViewCell.EditingStyle, Item) -> Void> {
         toFunction(#selector(UITableViewDataSource.tableView(_:commit:forRowAt:)), \.0, toClosure())
     }
-    
+
     var tableViewCanEditRow: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDataSource.tableView(_:canEditRowAt:)), toClosure())
     }
-    
-    //Reordering Table Rows
+
+    // MARK: - Reordering Table Rows
     var tableViewCanMoveRow: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDataSource.tableView(_:canMoveRowAt:)), toClosure())
     }
-    
+
     var tableViewMoveRow: TableFunction<(IndexPath, IndexPath), Void, (TableContext, IndexPath, IndexPath) -> Void> {
         toFunction(#selector(UITableViewDataSource.tableView(_:moveRowAt:to:)), toClosure())
     }
-    
-    //Configuring an Index
+
+    // MARK: - Configuring an Index
     var tableViewSectionIndexTitles: TableFunction<Void, [String]?, (TableContext) -> [String]?> {
         toFunction(#selector(UITableViewDataSource.sectionIndexTitles(for:)), toClosure())
     }
-    
+
     var tableViewSectionForSectionIndexTitle: TableFunction<(String, Int), Int, (TableContext, String, Int) -> Int> {
         toFunction(#selector(UITableViewDataSource.tableView(_:sectionForSectionIndexTitle:at:)), toClosure())
     }
 }
 
-//TableView Delegate
+// MARK: - TableView Delegate
 public extension DataSource {
-    //Configuring Rows for the Table View
+    // MARK: - Configuring Rows for the Table View
     var tableViewWillDisplayRow: TableItemFunction<(IndexPath, UITableViewCell), Void, (TableItemContext, UITableViewCell, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:willDisplay:forRowAt:)), \.0, toClosure())
     }
-    
+
     var tableViewIndentationLevelForRow: TableItemFunction<IndexPath, Int, (TableItemContext, Item) -> Int> {
         toFunction(#selector(UITableViewDelegate.tableView(_:indentationLevelForRowAt:)), toClosure())
     }
-    
+
     @available(iOS 11.0, *)
     var tableViewShouldSpringLoadRow: TableItemFunction<(IndexPath, UISpringLoadedInteractionContext), Bool, (TableItemContext, UISpringLoadedInteractionContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:shouldSpringLoadRowAt:with:)), \.0, toClosure())
     }
-    
-    //Responding to Row Selections
+
+    // MARK: - Responding to Row Selections
     var tableViewWillSelectRow: TableItemFunction<IndexPath, IndexPath?, (TableItemContext, Item) -> IndexPath?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:willSelectRowAt:)), toClosure())
     }
-    
+
     var tableViewDidSelectRow: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didSelectRowAt:)), toClosure())
     }
-    
+
     var tableViewWillDeselectRow: TableItemFunction<IndexPath, IndexPath?, (TableItemContext, Item) -> IndexPath?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:willDeselectRowAt:)), toClosure())
     }
-    
+
     var tableViewDidDeselectRow: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didDeselectRowAt:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var tableViewShouldBeginMultipleSelectionInteraction: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:shouldBeginMultipleSelectionInteractionAt:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var tableViewDidBeginMultipleSelectionInteraction: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableViewDidEndMultipleSelectionInteraction(_:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var tableViewDidEndMultipleSelectionInteraction: TableFunction<Void, Void, (TableContext) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didBeginMultipleSelectionInteractionAt:)), toClosure())
     }
-    
-    //Providing Custom Header and Footer Views
+
+    // MARK: - Providing Custom Header and Footer Views
     var tableViewViewHeaderForSection: TableSectionFunction<Int, UIView?, (TableSectionContext) -> UIView?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:viewForHeaderInSection:)), toClosure())
     }
-    
+
     var tableViewViewFooterForSection: TableSectionFunction<Int, UIView?, (TableSectionContext) -> UIView?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:viewForFooterInSection:)), toClosure())
     }
-    
+
     var tableViewWillDisplayHeaderView: TableSectionFunction<(Int, UIView), Void, (TableSectionContext, UIView) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:willDisplayHeaderView:forSection:)), \.0, toClosure())
     }
-    
+
     var tableViewWillDisplayFooterView: TableSectionFunction<(Int, UIView), Void, (TableSectionContext, UIView) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:willDisplayFooterView:forSection:)), \.0, toClosure())
     }
-    
-    //Providing Header, Footer, and Row Heights
+
+    // MARK: - Providing Header, Footer, and Row Heights
     var tableViewHeightForRow: TableItemFunction<IndexPath, CGFloat, (TableItemContext, Item) -> CGFloat> {
         toFunction(#selector(UITableViewDelegate.tableView(_:heightForRowAt:)), toClosure())
     }
-    
+
     var tableViewHeightForHeader: TableSectionFunction<Int, CGFloat, (TableSectionContext) -> CGFloat> {
         toFunction(#selector(UITableViewDelegate.tableView(_:heightForHeaderInSection:)), toClosure())
     }
-    
+
     var tableViewHeightForFooter: TableSectionFunction<Int, CGFloat, (TableSectionContext) -> CGFloat> {
         toFunction(#selector(UITableViewDelegate.tableView(_:heightForFooterInSection:)), toClosure())
     }
-    
-    //Estimating Heights for the Table's Content
+
+    // MARK: - Estimating Heights for the Table's Content
     var tableViewEstimatedHeightForRow: TableItemFunction<IndexPath, CGFloat, (TableItemContext, Item) -> CGFloat> {
         toFunction(#selector(UITableViewDelegate.tableView(_:estimatedHeightForRowAt:)), toClosure())
     }
-    
+
     var tableViewEstimatedHeightForHeader: TableSectionFunction<Int, CGFloat, (TableSectionContext) -> CGFloat> {
         toFunction(#selector(UITableViewDelegate.tableView(_:estimatedHeightForHeaderInSection:)), toClosure())
     }
-    
+
     var tableViewEstimatedHeightForFooter: TableSectionFunction<Int, CGFloat, (TableSectionContext) -> CGFloat> {
         toFunction(#selector(UITableViewDelegate.tableView(_:estimatedHeightForFooterInSection:)), toClosure())
     }
-    
-    //Managing Accessory Views
+
+    // MARK: - Managing Accessory Views
     var tableViewAccessoryButtonTapped: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:accessoryButtonTappedForRowWith:)), toClosure())
     }
-    
-    //Responding to Row Actions
+
+    // MARK: - Responding to Row Actions
     @available(iOS 11.0, *)
     var tableViewLeadingSwipeActionsConfiguration: TableItemFunction<IndexPath, UISwipeActionsConfiguration?, (TableItemContext, Item) -> UISwipeActionsConfiguration?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:leadingSwipeActionsConfigurationForRowAt:)), toClosure())
     }
-    
+
     @available(iOS 11.0, *)
     var tableViewTrailingSwipeActionsConfiguration: TableItemFunction<IndexPath, UISwipeActionsConfiguration?, (TableItemContext, Item) -> UISwipeActionsConfiguration?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:trailingSwipeActionsConfigurationForRowAt:)), toClosure())
     }
-    
+
     var tableViewShouldShowMenuForRow: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:shouldShowMenuForRowAt:)), toClosure())
     }
-    
+
     var tableViewCanPerformActionWithSender: TableItemFunction<(IndexPath, Selector, Any?), Bool, (TableItemContext, Selector, Any?, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:canPerformAction:forRowAt:withSender:)), \.0, toClosure())
     }
-    
+
     var tableViewPerformActionWithSender: TableItemFunction<(IndexPath, Selector, Any?), Void, (TableItemContext, Selector, Any?, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:performAction:forRowAt:withSender:)), \.0, toClosure())
     }
-    
+
     var tableViewEditActionsForRow: TableItemFunction<IndexPath, [UITableViewRowAction]?, (TableItemContext, Item) -> [UITableViewRowAction]?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:editActionsForRowAt:)), toClosure())
     }
-    
-    //Managing Table View Highlights
+
+    // MARK: - Managing Table View Highlights
     var tableViewShouldHighlight: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:shouldHighlightRowAt:)), toClosure())
     }
-    
+
     var tableViewDidHighlight: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didHighlightRowAt:)), toClosure())
     }
-    
+
     var tableViewDidUnhighlight: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didUnhighlightRowAt:)), toClosure())
     }
-    
-    //Editing Table Rows
+
+    // MARK: - Editing Table Rows
     var tableViewWillBeginEditing: TableItemFunction<IndexPath, Void, (TableItemContext, Item) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:willBeginEditingRowAt:)), toClosure())
     }
-    
+
     var tableViewDidEndEditing: TableFunction<IndexPath?, Void, (TableContext, IndexPath?) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didEndEditingRowAt:)), toClosure())
     }
-    
+
     var tableViewEditingStyle: TableItemFunction<IndexPath, UITableViewCell.EditingStyle, (TableItemContext, Item) -> UITableViewCell.EditingStyle> {
         toFunction(#selector(UITableViewDelegate.tableView(_:editingStyleForRowAt:)), toClosure())
     }
-    
+
     var tableViewTitleForDeleteConfirmationButton: TableItemFunction<IndexPath, String?, (TableItemContext, Item) -> String?> {
         toFunction(#selector(UITableViewDelegate.tableView(_:titleForDeleteConfirmationButtonForRowAt:)), toClosure())
     }
-    
+
     var tableViewShouldIndentWhileEditing: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:shouldIndentWhileEditingRowAt:)), toClosure())
     }
-    
-    //Reordering Table Rows
+
+    // MARK: - Reordering Table Rows
     var tableViewTargetIndexPathForMoveFromRowAtToProposedIndexPath: TableFunction<(IndexPath, IndexPath), IndexPath, (TableContext, IndexPath, IndexPath) -> IndexPath> {
         toFunction(#selector(UITableViewDelegate.tableView(_:targetIndexPathForMoveFromRowAt:toProposedIndexPath:)), toClosure())
     }
-            
-    //Tracking the Removal of Views
+
+    // MARK: - Tracking the Removal of Views
     var tableViewdidEndDisplayingForRowAt: TableFunction<(UITableViewCell, IndexPath), Void, (TableContext, UITableViewCell, IndexPath) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didEndDisplaying:forRowAt:)), toClosure())
     }
-    
+
     var tableViewDidEndDisplayingHeaderView: TableFunction<(UIView, Int), Void, (TableContext, UIView, Int) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didEndDisplayingHeaderView:forSection:)), toClosure())
     }
-    
+
     var tableViewDidEndDisplayingFooterView: TableFunction<(UIView, Int), Void, (TableContext, UIView, Int) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didEndDisplayingFooterView:forSection:)), toClosure())
     }
-    
-    //Managing Table View Focus
+
+    // MARK: - Managing Table View Focus
     var tableViewCanFocusRow: TableItemFunction<IndexPath, Bool, (TableItemContext, Item) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:canFocusRowAt:)), toClosure())
     }
-    
+
     var tableViewShouldUpdateFocusIn: TableFunction<UITableViewFocusUpdateContext, Bool, (TableContext, UITableViewFocusUpdateContext) -> Bool> {
         toFunction(#selector(UITableViewDelegate.tableView(_:shouldUpdateFocusIn:)), toClosure())
     }
-    
+
     var tableViewDidUpdateFocusInWith: TableFunction<(UITableViewFocusUpdateContext, UIFocusAnimationCoordinator), Void, (TableContext, UITableViewFocusUpdateContext, UIFocusAnimationCoordinator) -> Void> {
         toFunction(#selector(UITableViewDelegate.tableView(_:didUpdateFocusIn:with:)), toClosure())
     }
-    
+
     var tableViewIndexPathForPreferredFocusedView: TableFunction<Void, IndexPath?, (TableContext) -> IndexPath?> {
         toFunction(#selector(UITableViewDelegate.indexPathForPreferredFocusedView(in:)), toClosure())
     }
-    
-    //Instance Methods
+
+    // MARK: - Instance Methods
     @available(iOS 13.0, *)
     var tableViewContextMenuConfigurationForRow: TableItemFunction<(IndexPath, CGPoint), UIContextMenuConfiguration, (TableItemContext, CGPoint, Item) -> UIContextMenuConfiguration> {
         toFunction(#selector(UITableViewDelegate.tableView(_:contextMenuConfigurationForRowAt:point:)), \.0, toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var tableViewPreviewForDismissingContextMenuWithConfiguration: TableFunction<UIContextMenuConfiguration, UITargetedPreview, (TableContext, UIContextMenuConfiguration) -> UITargetedPreview> {
         toFunction(#selector(UITableViewDelegate.tableView(_:previewForDismissingContextMenuWithConfiguration:)), toClosure())
     }
-    
+
     @available(iOS 13.0, *)
     var tableViewPreviewForHighlightingContextMenuWithConfiguration: TableFunction<UIContextMenuConfiguration, UITargetedPreview, (TableContext, UIContextMenuConfiguration) -> UITargetedPreview> {
         toFunction(#selector(UITableViewDelegate.tableView(_:previewForHighlightingContextMenuWithConfiguration:)), toClosure())
@@ -274,6 +276,5 @@ public extension DataSource {
         toFunction(#selector(UITableViewDelegate.tableView(_:willPerformPreviewActionForMenuWith:animator:)), toClosure())
     }
 }
-
 
 #endif

--- a/Sources/ListAdapter/NestedAdapter.swift
+++ b/Sources/ListAdapter/NestedAdapter.swift
@@ -23,18 +23,18 @@ public extension ListIndexContext where Index == IndexPath {
             completion: completion
         )
         var coordinator = list.listCoordinator
-        setNestedCache { [weak collectionView] Base in
-            guard let Base = Base as? Base.Item,
+        setNestedCache { [weak collectionView] base in
+            guard let baseItem = base as? Base.Item,
                   let collectionView = collectionView,
                   collectionView.isCoordinator(coordinator)
             else { return }
-            let adapter = Base[keyPath: keyPath]
+            let adapter = baseItem[keyPath: keyPath]
             let list = adapter.apply(by: collectionView, animated: animated, completion: completion)
             coordinator = list.listCoordinator
         }
         return list
     }
-    
+
     @discardableResult
     func nestedAdapter<Adapter: TableListAdapter>(
         _ keyPath: KeyPath<Base.Item, Adapter>,
@@ -50,12 +50,12 @@ public extension ListIndexContext where Index == IndexPath {
             completion: completion
         )
         var coordinator = list.listCoordinator
-        setNestedCache { [weak tableView] Base in
-            guard let Base = Base as? Base.Item,
+        setNestedCache { [weak tableView] base in
+            guard let baseItem = base as? Base.Item,
                   let tableView = tableView,
                   tableView.isCoordinator(coordinator)
             else { return }
-            let adapter = Base[keyPath: keyPath]
+            let adapter = baseItem[keyPath: keyPath]
             let list = adapter.apply(by: tableView, animated: animated, completion: completion)
             coordinator = list.listCoordinator
         }

--- a/Sources/ListAdapter/ScrollListAdapter.swift
+++ b/Sources/ListAdapter/ScrollListAdapter.swift
@@ -20,42 +20,42 @@ where Source.AdapterBase == Source {
     public typealias Item = Source.Item
     public typealias SourceBase = Source.SourceBase
     public typealias AdapterBase = Source
-    
+
     public var source: Source
     public var sourceBase: SourceBase { source.sourceBase }
     public var adapterBase: Source { source }
-    
+
     public var listUpdate: ListUpdate<SourceBase>.Whole { source.listUpdate }
     public var listDiffer: ListDiffer<SourceBase> { source.listDiffer }
     public var listOptions: ListOptions { source.listOptions }
-    
+
     public var listDelegate: ListDelegate
     public var listCoordinatorContext: ListCoordinatorContext<SourceBase> {
         source.listCoordinatorContext.context(with: listDelegate)
     }
-    
+
     public lazy var listCoordinator = source.listCoordinator
     public lazy var coordinatorStorage = listCoordinator.storage.or({
         let storage = CoordinatorStorage<SourceBase>()
         listCoordinator.storage = storage
         return storage
     }())
-    
+
     public var scrollList: ScrollList<Source> { self }
     public var wrappedValue: Source {
         get { source }
         set { source = newValue }
     }
-    
+
     public subscript<Value>(dynamicMember path: KeyPath<Source, Value>) -> Value {
         source[keyPath: path]
     }
-    
+
     public subscript<Value>(dynamicMember path: WritableKeyPath<Source, Value>) -> Value {
         get { source[keyPath: path] }
         set { source[keyPath: path] = newValue }
     }
-    
+
     required init<OtherSource: DataSource>(
         _ source: OtherSource,
         options: ListOptions = .init()
@@ -63,12 +63,12 @@ where Source.AdapterBase == Source {
         self.source = AnySources(source, options: options)
         self.listDelegate = .init()
     }
-    
+
     required init(_ source: Source) {
         self.source = source
         self.listDelegate = source.listDelegate
     }
-    
+
     required init(_ source: Source, listDelegate: ListDelegate) {
         self.source = source
         self.listDelegate = listDelegate
@@ -77,6 +77,6 @@ where Source.AdapterBase == Source {
 
 extension ScrollList: ItemCachedDataSource where Source: ItemCachedDataSource {
     public typealias ItemCache = Source.ItemCache
-    
+
     public var itemCached: ItemCached<Source.SourceBase, Source.ItemCache> { source.itemCached }
 }

--- a/Sources/ListAdapter/TableListAdapter.swift
+++ b/Sources/ListAdapter/TableListAdapter.swift
@@ -37,7 +37,7 @@ public extension TableListAdapter {
         )
         return tableList
     }
-    
+
     @discardableResult
     func apply(
         by tableView: TableView,

--- a/Sources/ListKit.swift
+++ b/Sources/ListKit.swift
@@ -2,8 +2,8 @@ public typealias UpdatableTableListAdapter = TableListAdapter & UpdatableDataSou
 public typealias UpdatableCollectionListAdapter = CollectionListAdapter & UpdatableDataSource
 
 public enum Log {
-    public static var logger: ((String) -> Void)? = nil
-    
+    public static var logger: ((String) -> Void)?
+
     static func log(_ text: @autoclosure () -> String?) {
         guard let logger = logger else { return }
         text().map(logger)

--- a/Sources/ListView/ListView+AppKit/NSListView.swift
+++ b/Sources/ListView/ListView+AppKit/NSListView.swift
@@ -9,7 +9,7 @@
 import AppKit
 
 public protocol NSListView: NSView, ListView {
-    
+
 }
 
 #endif

--- a/Sources/ListView/ListView+UIKit/ListView+UITableView.swift
+++ b/Sources/ListView/ListView+UIKit/ListView+UITableView.swift
@@ -14,12 +14,12 @@ public typealias TableView = UITableView
 
 extension UITableView: UIListView, SetuptableListView {
     public typealias Cell = UITableViewCell
-    
+
     func setup(with listDelegate: Delegate) {
         dataSource = listDelegate
         delegate = listDelegate
     }
-    
+
     func isDelegate(_ listDelegate: Delegate) -> Bool {
         dataSource === listDelegate && delegate === listDelegate
     }
@@ -30,12 +30,12 @@ public extension UITableView {
         get { Associator.getValue(key: &listViewDefaultAnimationKey, from: self) ?? .fade }
         set { Associator.set(value: newValue, key: &listViewDefaultAnimationKey, to: self) }
     }
-    
+
     func resetDelegates(toNil: Bool) {
         dataSource = toNil ? nil : dataSource
         delegate = toNil ? nil : delegate
     }
-    
+
     func reloadSynchronously(animated: Bool = true) {
         if animated {
             reloadData()
@@ -49,7 +49,7 @@ public extension UITableView {
             layoutIfNeeded()
         }
     }
-    
+
     func perform(_ update: () -> Void, animated: Bool, completion: ((Bool) -> Void)?) {
         func _update() {
             if #available(iOS 11.0, *) {
@@ -70,57 +70,57 @@ public extension UITableView {
             CATransaction.commit()
         }
     }
-    
+
     func insertItems(at indexPaths: [IndexPath]) {
         insertRows(at: indexPaths, with: defaultAnimation.insertRows)
     }
-    
+
     func deleteItems(at indexPaths: [IndexPath]) {
         deleteRows(at: indexPaths, with: defaultAnimation.deleteRows)
     }
-    
+
     func reloadItems(at indexPaths: [IndexPath]) {
         reloadRows(at: indexPaths, with: defaultAnimation.reloadRows)
     }
-    
+
     func moveItem(at indexPath: IndexPath, to newIndexPath: IndexPath) {
         moveRow(at: indexPath, to: newIndexPath)
     }
-    
+
     func insertSections(_ sections: IndexSet) {
         insertSections(sections, with: defaultAnimation.insertSections)
     }
-    
+
     func deleteSections(_ sections: IndexSet) {
         deleteSections(sections, with: defaultAnimation.deleteSections)
     }
-    
+
     func reloadSections(_ sections: IndexSet) {
         reloadSections(sections, with: defaultAnimation.reloadSections)
     }
-    
+
     func selectItem(at indexPath: IndexPath?, animated: Bool, scrollPosition: ScrollPosition) {
         selectRow(at: indexPath, animated: animated, scrollPosition: scrollPosition)
     }
-    
+
     func deselectItem(at indexPath: IndexPath, animated: Bool) {
         deselectRow(at: indexPath, animated: animated)
     }
-    
+
     func register(supplementaryViewType: SupplementaryViewType, _ supplementaryClass: AnyClass?, identifier: String) {
         switch supplementaryViewType {
         case .header: register(supplementaryClass, forHeaderFooterViewReuseIdentifier: identifier)
         case .footer: register(supplementaryClass, forHeaderFooterViewReuseIdentifier: identifier)
         }
     }
-    
+
     func register(supplementaryViewType: SupplementaryViewType, _ nib: UINib?, identifier: String) {
         switch supplementaryViewType {
         case .header: register(nib, forHeaderFooterViewReuseIdentifier: identifier)
         case .footer: register(nib, forHeaderFooterViewReuseIdentifier: identifier)
         }
     }
-    
+
     func cellForItem(at indexPath: IndexPath) -> UITableViewCell? {
         cellForRow(at: indexPath)
     }
@@ -131,7 +131,7 @@ public extension UITableView {
         case header
         case footer
     }
-    
+
     struct Animation: ListViewAnimationOption {
         let deleteSections: RowAnimation
         let insertSections: RowAnimation
@@ -139,7 +139,7 @@ public extension UITableView {
         let deleteRows: RowAnimation
         let insertRows: RowAnimation
         let reloadRows: RowAnimation
-        
+
         public init(animated: Bool) {
             if animated {
                 self.init()
@@ -147,7 +147,7 @@ public extension UITableView {
                 self.init(allUsing: .none)
             }
         }
-        
+
         public init(
             deleteSections: RowAnimation = .none,
             insertSections: RowAnimation = .none,
@@ -163,11 +163,11 @@ public extension UITableView {
             self.insertRows = insertRows
             self.reloadRows = reloadRows
         }
-        
+
         public init() {
             self.init(allUsing: .automatic)
         }
-        
+
         init(allUsing animation: RowAnimation) {
             deleteSections = animation
             insertSections = animation

--- a/Sources/ListView/ListView+UIKit/ListView+UIcollectionView.swift
+++ b/Sources/ListView/ListView+UIKit/ListView+UIcollectionView.swift
@@ -13,12 +13,12 @@ public typealias CollectionView = UICollectionView
 extension UICollectionView: UIListView, SetuptableListView {
     public typealias Cell = UICollectionViewCell
     public typealias Animation = Bool
-    
+
     func setup(with listDelegate: Delegate) {
         dataSource = listDelegate
         delegate = listDelegate
     }
-    
+
     func isDelegate(_ listDelegate: Delegate) -> Bool {
         dataSource === listDelegate && delegate === listDelegate
     }
@@ -29,12 +29,12 @@ public extension UICollectionView {
         get { Associator.getValue(key: &Self.listViewDefaultAnimationKey, from: self) ?? true }
         set { Associator.set(value: newValue, key: &Self.listViewDefaultAnimationKey, to: self) }
     }
-    
+
     func resetDelegates(toNil: Bool) {
         dataSource = toNil ? nil : dataSource
         delegate = toNil ? nil : delegate
     }
-    
+
     func reloadSynchronously(animated: Bool = true) {
         if animated {
             reloadData()
@@ -48,7 +48,7 @@ public extension UICollectionView {
             layoutIfNeeded()
         }
     }
-    
+
     func perform(_ update: () -> Void, animated: Bool, completion: ((Bool) -> Void)? = nil) {
         if animated {
             performBatchUpdates(update, completion: completion)
@@ -59,23 +59,23 @@ public extension UICollectionView {
             CATransaction.commit()
         }
     }
-    
+
     func register(_ cellClass: AnyClass?, forCellReuseIdentifier identifier: String) {
         register(cellClass, forCellWithReuseIdentifier: identifier)
     }
-    
+
     func register(_ nib: UINib?, forCellReuseIdentifier identifier: String) {
         register(nib, forCellWithReuseIdentifier: identifier)
     }
-    
+
     func register(supplementaryViewType: SupplementaryViewType, _ nib: UINib?, identifier: String) {
         register(nib, forSupplementaryViewOfKind: kind(for: supplementaryViewType), withReuseIdentifier: identifier)
     }
-    
+
     func register(supplementaryViewType: SupplementaryViewType, _ supplementaryClass: AnyClass?, identifier: String) {
         register(supplementaryClass, forSupplementaryViewOfKind: kind(for: supplementaryViewType), withReuseIdentifier: identifier)
     }
-    
+
     func dequeueReusableCell(withIdentifier identifier: String, for indexPath: IndexPath) -> UICollectionViewCell {
         dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath)
     }
@@ -86,7 +86,7 @@ public extension UICollectionView {
         case header
         case footer
         case custom(String)
-        
+
         public init(rawValue: String) {
             switch rawValue {
             case UICollectionView.elementKindSectionHeader: self = .header
@@ -94,7 +94,7 @@ public extension UICollectionView {
             default: self = .custom(rawValue)
             }
         }
-        
+
         public var rawValue: String {
             switch self {
             case .header: return UICollectionView.elementKindSectionHeader
@@ -107,7 +107,7 @@ public extension UICollectionView {
 
 extension UICollectionView {
     static var listViewDefaultAnimationKey: Void?
-    
+
     func kind(for kind: SupplementaryViewType) -> String {
         switch kind {
         case .header: return UICollectionView.elementKindSectionHeader

--- a/Sources/ListView/ListView+UIKit/ListViewStorage+UIKit.swift
+++ b/Sources/ListView/ListView+UIKit/ListViewStorage+UIKit.swift
@@ -36,7 +36,7 @@ public extension UIListView {
         let cell = dequeueReusableCell(withIdentifier: storyBoardIdentifier, for: indexPath)
         return cell as! CustomCell
     }
-    
+
     func dequeueReusableCell<CustomCell: UIView>(
         _ cellClass: CustomCell.Type,
         withNibName nibName: String,
@@ -56,13 +56,13 @@ public extension UIListView {
 }
 
 public extension UICollectionView {
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UICollectionReusableView>(
+    func dequeueReusableSupplementaryView<SupplementaryView: UICollectionReusableView>(
         type: SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         identifier: String = "",
         indexPath: IndexPath
-    ) -> CustomSupplementaryView {
-        let id = NSStringFromClass(CustomSupplementaryView.self) + type.rawValue + identifier
+    ) -> SupplementaryView {
+        let id = NSStringFromClass(SupplementaryView.self) + type.rawValue + identifier
         if _storage.registeredSupplementaryIdentifiers[type]?.contains(id) != true {
             var identifiers = _storage.registeredSupplementaryIdentifiers[type] ?? .init()
             identifiers.insert(id)
@@ -74,16 +74,16 @@ public extension UICollectionView {
             withReuseIdentifier: id,
             for: indexPath
         )
-        return supplementaryView as! CustomSupplementaryView
+        return supplementaryView as! SupplementaryView
     }
-    
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UICollectionReusableView>(
+
+    func dequeueReusableSupplementaryView<SupplementaryView: UICollectionReusableView>(
         type: SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         nibName: String,
         bundle: Bundle? = nil,
         indexPath: IndexPath
-    ) -> CustomSupplementaryView {
+    ) -> SupplementaryView {
         let nib = UINib(nibName: nibName, bundle: bundle)
         let id = nibName + type.rawValue
         if _storage.registeredSupplementaryNibName[type]?.contains(id) != true {
@@ -97,17 +97,17 @@ public extension UICollectionView {
             withReuseIdentifier: id,
             for: indexPath
         )
-        return supplementaryView as! CustomSupplementaryView
+        return supplementaryView as! SupplementaryView
     }
 }
 
 public extension UITableView {
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UITableViewHeaderFooterView>(
+    func dequeueReusableSupplementaryView<SupplementaryView: UITableViewHeaderFooterView>(
         type: SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         identifier: String = ""
-    ) -> CustomSupplementaryView? {
-        let id = NSStringFromClass(CustomSupplementaryView.self) + type.rawValue + identifier
+    ) -> SupplementaryView? {
+        let id = NSStringFromClass(SupplementaryView.self) + type.rawValue + identifier
         if _storage.registeredSupplementaryIdentifiers[type]?.contains(id) != true {
             var identifiers = _storage.registeredSupplementaryIdentifiers[type] ?? .init()
             identifiers.insert(id)
@@ -115,15 +115,15 @@ public extension UITableView {
             register(supplementaryViewType: type, supplementaryClass, identifier: id)
         }
         let supplementaryView = dequeueReusableHeaderFooterView(withIdentifier: id)
-        return supplementaryView as? CustomSupplementaryView
+        return supplementaryView as? SupplementaryView
     }
-    
-    func dequeueReusableSupplementaryView<CustomSupplementaryView: UITableViewHeaderFooterView>(
+
+    func dequeueReusableSupplementaryView<SupplementaryView: UITableViewHeaderFooterView>(
         type: SupplementaryViewType,
-        _ supplementaryClass: CustomSupplementaryView.Type,
+        _ supplementaryClass: SupplementaryView.Type,
         nibName: String,
         bundle: Bundle? = nil
-    ) -> CustomSupplementaryView? {
+    ) -> SupplementaryView? {
         let nib = UINib(nibName: nibName, bundle: bundle)
         let id = nibName + type.rawValue
         if _storage.registeredSupplementaryNibName[type]?.contains(id) != true {
@@ -133,7 +133,7 @@ public extension UITableView {
             register(supplementaryViewType: type, nib, identifier: id)
         }
         let supplementaryView = dequeueReusableHeaderFooterView(withIdentifier: id)
-        return supplementaryView as? CustomSupplementaryView
+        return supplementaryView as? SupplementaryView
     }
 }
 

--- a/Sources/ListView/ListView+UIKit/UIListView.swift
+++ b/Sources/ListView/ListView+UIKit/UIListView.swift
@@ -13,18 +13,18 @@ public protocol UIListView: UIScrollView, ListView {
     associatedtype Animation: ListViewAnimationOption
     associatedtype ScrollPosition
     associatedtype SupplementaryViewType
-    
+
     func register(_ cellClass: AnyClass?, forCellReuseIdentifier identifier: String)
     func register(_ nib: UINib?, forCellReuseIdentifier identifier: String)
     func register(supplementaryViewType: SupplementaryViewType, _ supplementaryClass: AnyClass?, identifier: String)
     func register(supplementaryViewType: SupplementaryViewType, _ nib: UINib?, identifier: String)
     func dequeueReusableCell(withIdentifier identifier: String, for indexPath: IndexPath) -> Cell
-    
+
     func cellForItem(at indexPath: IndexPath) -> Cell?
-    
+
     func selectItem(at indexPath: IndexPath?, animated: Bool, scrollPosition: ScrollPosition)
     func deselectItem(at indexPath: IndexPath, animated: Bool)
-    
+
     var defaultAnimation: Animation { get set }
 }
 

--- a/Sources/ListView/ListView.swift
+++ b/Sources/ListView/ListView.swift
@@ -11,7 +11,7 @@ public protocol ListView: NSObject {
     func resetDelegates(toNil: Bool)
     func reloadSynchronously(animated: Bool)
     func perform(_ update: () -> Void, animated: Bool, completion: ((Bool) -> Void)?)
-    
+
     func insertItems(at indexPaths: [IndexPath])
     func deleteItems(at indexPaths: [IndexPath])
     func reloadItems(at indexPaths: [IndexPath])
@@ -33,7 +33,7 @@ extension SetuptableListView {
     var listDelegate: Delegate {
         Associator.getValue(key: &listDelegateKey, from: self, initialValue: .init(self))
     }
-    
+
     func isCoordinator(_ coordinator: AnyObject) -> Bool {
         if let delegate: Delegate = Associator.getValue(key: &listDelegateKey, from: self) {
             return isDelegate(delegate) && delegate.context?.isCoordinator(coordinator) ?? false

--- a/Sources/Source/AnySources.swift
+++ b/Sources/Source/AnySources.swift
@@ -9,14 +9,14 @@ public struct AnySources: DataSource {
     public typealias Item = Any
     public typealias SourceBase = Self
     let coordinatorMaker: (Self) -> ListCoordinator<AnySources>
-    
+
     public let source: Any
     public let listDiffer: ListDiffer<AnySources>
     public let listOptions: ListOptions
     public let listUpdate: ListUpdate<SourceBase>.Whole
-    
+
     public var listCoordinator: ListCoordinator<Self> { coordinatorMaker(self) }
-    
+
     public init<Source: DataSource>(_ dataSource: Source, options: ListOptions = .init()) {
         source = dataSource
         listDiffer = .init(dataSource.listDiffer) { (($0.source) as! Source).sourceBase }

--- a/Sources/Source/AnySourcesBuilder.swift
+++ b/Sources/Source/AnySourcesBuilder.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/12/11.
 //
 
+// swiftlint:disable line_length function_parameter_count
+
 public extension AnySources {
     init<Source: DataSource>(
         options: ListOptions = .init(),
@@ -19,57 +21,57 @@ public struct AnySourcesBuilder {
     public static func buildIf<S: DataSource>(_ content: S?) -> S? {
         content
     }
-    
+
     public static func buildEither<TrueContent, FalseContent>(
         trueContent: TrueContent
     ) -> ConditionalSources<TrueContent, FalseContent>
     where TrueContent: TableListAdapter, FalseContent: TableListAdapter {
         .trueContent(trueContent)
     }
-    
+
     public static func buildEither<TrueContent, FalseContent>(
         falseContent: FalseContent
     ) -> ConditionalSources<TrueContent, FalseContent>
     where TrueContent: TableListAdapter, FalseContent: TableListAdapter {
         .falseContent(falseContent)
     }
-    
+
     public static func buildBlock<S: DataSource>(_ content: S) -> S {
         content
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource>(_ s0: S0, _ s1: S1) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource, S4: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3), AnySources(s4)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource, S4: DataSource, S5: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3), AnySources(s4), AnySources(s5)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource, S4: DataSource, S5: DataSource, S6: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3), AnySources(s4), AnySources(s5), AnySources(s6)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource, S4: DataSource, S5: DataSource, S6: DataSource, S7: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3), AnySources(s4), AnySources(s5), AnySources(s6), AnySources(s7)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource, S4: DataSource, S5: DataSource, S6: DataSource, S7: DataSource, S8: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7, _ s8: S8) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3), AnySources(s4), AnySources(s5), AnySources(s6), AnySources(s7)])
     }
-    
+
     public static func buildBlock<S0: DataSource, S1: DataSource, S2: DataSource, S3: DataSource, S4: DataSource, S5: DataSource, S6: DataSource, S7: DataSource, S8: DataSource, S9: DataSource>(_ s0: S0, _ s1: S1, _ s2: S2, _ s3: S3, _ s4: S4, _ s5: S5, _ s6: S6, _ s7: S7, _ s8: S8, _ s9: S9) -> Sources<[AnySources], Any> {
         Sources(dataSources: [AnySources(s8), AnySources(s0), AnySources(s1), AnySources(s2), AnySources(s3), AnySources(s4), AnySources(s5), AnySources(s6), AnySources(s7), AnySources(s8), AnySources(s9)])
     }

--- a/Sources/Source/ConditionalSources.swift
+++ b/Sources/Source/ConditionalSources.swift
@@ -8,17 +8,17 @@
 public enum ConditionalSources<TrueContent: DataSource, FalseContent: DataSource>: DataSource {
     public typealias Item = Any
     public typealias SourceBase = Self
-    
+
     case trueContent(TrueContent)
     case falseContent(FalseContent)
-    
+
     public var source: [AnySources] {
         switch self {
         case let .trueContent(content): return [.init(content)]
         case let .falseContent(content): return [.init(content)]
         }
     }
-    
+
     public var listDiffer: ListDiffer<ConditionalSources<TrueContent, FalseContent>> {
         switch self {
         case let .trueContent(content):
@@ -27,14 +27,14 @@ public enum ConditionalSources<TrueContent: DataSource, FalseContent: DataSource
             return .init(content.listDiffer) { _ in content.sourceBase }
         }
     }
-    
+
     public var listOptions: ListOptions {
         switch self {
         case let .trueContent(content): return content.listOptions
         case let .falseContent(content): return content.listOptions
         }
     }
-    
+
     public var listUpdate: ListUpdate<ConditionalSources<TrueContent, FalseContent>>.Whole {
         switch self {
         case let .trueContent(content):
@@ -44,7 +44,6 @@ public enum ConditionalSources<TrueContent: DataSource, FalseContent: DataSource
         }
     }
 }
-
 
 extension ConditionalSources: ScrollListAdapter
 where TrueContent: ScrollListAdapter, FalseContent: ScrollListAdapter { }

--- a/Sources/Source/Sources+Extensions/Sources+Item.swift
+++ b/Sources/Source/Sources+Extensions/Sources+Item.swift
@@ -32,69 +32,69 @@ public extension Sources where Source == Item {
     ) {
         self.init(id, item: wrappedValue, update: update, options: options)
     }
-    
+
     init(item: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: item, update: .reload, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: wrappedValue, update: .reload, options: options)
     }
 }
 
-//Equatable
+// MARK: - Equatable
 public extension Sources where Source == Item, Item: Equatable {
     init(item: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: item, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Hashable
+// MARK: - Hashable
 public extension Sources where Source == Item, Item: Hashable {
     init(item: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: item, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable
+// MARK: - Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources where Source == Item, Item: Identifiable {
     init(item: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: item, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Equatable
+// MARK: - Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources where Source == Item, Item: Identifiable, Item: Equatable {
     init(item: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: item, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Hashable
+// MARK: - Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources where Source == Item, Item: Identifiable, Item: Hashable {
     init(item: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: item, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, item: wrappedValue, update: .diff, options: options)
     }

--- a/Sources/Source/Sources+Extensions/Sources+Items.swift
+++ b/Sources/Source/Sources+Extensions/Sources+Items.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/1/16.
 //
 
+// swiftlint:disable opening_brace
+
 extension Sources where Source: Collection, Source.Element == Item {
     init(_ id: AnyHashable?, items: Source, update: ListUpdate<SourceBase>.Whole, options: ListOptions) {
         self.sourceValue = .value(items)
@@ -34,7 +36,7 @@ public extension Sources where Source: Collection, Source.Element == Item {
     ) {
         self.init(id, items: items, update: update, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -43,11 +45,11 @@ public extension Sources where Source: Collection, Source.Element == Item {
     ) {
         self.init(id, items: wrappedValue, update: update, options: options)
     }
-    
+
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .reload, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .reload, options: options)
     }
@@ -62,7 +64,7 @@ public extension Sources where Source: RangeReplaceableCollection, Source.Elemen
     ) {
         self.init(id, items: items, update: update, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -71,17 +73,17 @@ public extension Sources where Source: RangeReplaceableCollection, Source.Elemen
     ) {
         self.init(id, items: wrappedValue, update: update, options: options)
     }
-    
+
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .reload, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .reload, options: options)
     }
 }
 
-//Equatable
+// MARK: - Equatable
 public extension Sources
 where
     Source: Collection,
@@ -91,7 +93,7 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
@@ -106,13 +108,13 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Hashable
+// MARK: - Hashable
 public extension Sources
 where
     Source: Collection,
@@ -122,7 +124,7 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
@@ -137,13 +139,13 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable
+// MARK: - Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -154,7 +156,7 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
@@ -170,13 +172,13 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Equatable
+// MARK: - Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -188,7 +190,7 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
@@ -205,13 +207,13 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Hashable
+// MARK: - Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -223,7 +225,7 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
@@ -240,9 +242,8 @@ where
     init(items: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: items, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, items: wrappedValue, update: .diff, options: options)
     }
 }
-

--- a/Sources/Source/Sources+Extensions/Sources+Sections.swift
+++ b/Sources/Source/Sources+Extensions/Sources+Sections.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/1/16.
 //
 
+// swiftlint:disable opening_brace
+
 extension Sources
 where
     Source: Collection,
@@ -59,7 +61,7 @@ where
     ) {
         self.init(id, sections: sections, update: update, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -68,11 +70,11 @@ where
     ) {
         self.init(id, sections: wrappedValue, update: update, options: options)
     }
-    
+
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .reload, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .reload, options: options)
     }
@@ -92,7 +94,7 @@ where
     ) {
         self.init(id, sections: sections, update: update, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -101,17 +103,17 @@ where
     ) {
         self.init(id, sections: wrappedValue, update: update, options: options)
     }
-    
+
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .reload, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .reload, options: options)
     }
 }
 
-//Equatable
+// MARK: - Equatable
 public extension Sources
 where
     Source: Collection,
@@ -122,7 +124,7 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
@@ -138,13 +140,13 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Hashable
+// MARK: - Hashable
 public extension Sources
 where
     Source: Collection,
@@ -155,7 +157,7 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
@@ -171,13 +173,13 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable
+// MARK: - Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -189,7 +191,7 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
@@ -206,13 +208,13 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Equatable
+// MARK: - Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -225,7 +227,7 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
@@ -243,13 +245,13 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Hashable
+// MARK: - Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -262,7 +264,7 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }
@@ -280,7 +282,7 @@ where
     init(sections: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: sections, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, sections: wrappedValue, update: .diff, options: options)
     }

--- a/Sources/Source/Sources+Extensions/Sources+Source.swift
+++ b/Sources/Source/Sources+Extensions/Sources+Source.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/1/16.
 //
 
+// swiftlint:disable opening_brace
+
 extension Sources where Source: DataSource, Source.Item == Item {
     init(
         _ id: AnyHashable?,
@@ -18,7 +20,7 @@ extension Sources where Source: DataSource, Source.Item == Item {
         self.listOptions = options
         self.coordinatorMaker = { $0.coordinator(with: WrapperCoordinator(wrapper: $0)) }
     }
-    
+
     init(
         _ id: AnyHashable? = nil,
         update: ListUpdate<SourceBase>.Whole,
@@ -42,7 +44,7 @@ public extension Sources where Source: DataSource, Source.Item == Item {
     ) {
         self.init(id, dataSource: dataSource, update: update, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -51,39 +53,39 @@ public extension Sources where Source: DataSource, Source.Item == Item {
     ) {
         self.init(id, dataSource: wrappedValue, update: update, options: options)
     }
-    
+
     init(dataSource: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: dataSource, update: .reload, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: wrappedValue, update: .reload, options: options)
     }
 }
 
-//Equatable
+// MARK: - Equatable
 public extension Sources where Source: DataSource, Source.Item == Item, Item: Equatable {
     init(dataSource: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: dataSource, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Hashable
+// MARK: - Hashable
 public extension Sources where Source: DataSource, Source.Item == Item, Item: Hashable {
     init(dataSource: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: dataSource, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable
+// MARK: - Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -94,13 +96,13 @@ where
     init(dataSource: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: dataSource, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Equatable
+// MARK: - Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -112,13 +114,13 @@ where
     init(dataSource: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: dataSource, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: wrappedValue, update: .diff, options: options)
     }
 }
 
-//Identifiable + Hashable
+// MARK: - Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -130,9 +132,8 @@ where
     init(dataSource: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: dataSource, update: .diff, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSource: wrappedValue, update: .diff, options: options)
     }
 }
-

--- a/Sources/Source/Sources+Extensions/Sources+Sources.swift
+++ b/Sources/Source/Sources+Extensions/Sources+Sources.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2020/1/16.
 //
 
+// swiftlint:disable opening_brace
+
 extension Sources
 where
     Source: RangeReplaceableCollection,
@@ -39,7 +41,7 @@ where
     ) {
         self.init(id, dataSources: dataSources, update: update, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -48,17 +50,17 @@ where
     ) {
         self.init(id, dataSources: wrappedValue, update: update, options: options)
     }
-    
+
     init(dataSources: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSources: dataSources, update: .subupdate, options: options)
     }
-    
+
     init(wrappedValue: Source, id: AnyHashable? = nil, options: ListOptions = .none) {
         self.init(id, dataSources: wrappedValue, update: .subupdate, options: options)
     }
 }
 
-//Equatable
+// MARK: - Equatable
 public extension Sources
 where
     Source: RangeReplaceableCollection,
@@ -74,7 +76,7 @@ where
     ) {
         self.init(id, dataSources: dataSources, update: .diff, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -85,7 +87,7 @@ where
     }
 }
 
-//Hashable
+// MARK: - Hashable
 public extension Sources
 where
     Source: RangeReplaceableCollection,
@@ -101,7 +103,7 @@ where
     ) {
         self.init(id, dataSources: dataSources, update: .diff, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -112,7 +114,7 @@ where
     }
 }
 
-//Identifiable
+// MARK: - Identifiable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -129,7 +131,7 @@ where
     ) {
         self.init(id, dataSources: dataSources, update: .diff, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -140,7 +142,7 @@ where
     }
 }
 
-//Identifiable + Equatable
+// MARK: - Identifiable + Equatable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -158,7 +160,7 @@ where
     ) {
         self.init(id, dataSources: dataSources, update: .diff, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,
@@ -169,7 +171,7 @@ where
     }
 }
 
-//Identifiable + Hashable
+// MARK: - Identifiable + Hashable
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Sources
 where
@@ -187,7 +189,7 @@ where
     ) {
         self.init(id, dataSources: dataSources, update: .diff, options: options)
     }
-    
+
     init(
         wrappedValue: Source,
         id: AnyHashable? = nil,

--- a/Sources/Source/Sources.swift
+++ b/Sources/Source/Sources.swift
@@ -12,11 +12,11 @@ public struct Sources<Source, Item>: UpdatableDataSource {
         case value(Source)
         case getter(() -> Source)
     }
-    
+
     public typealias SourceBase = Self
     let sourceValue: Value
     let coordinatorMaker: (Self) -> ListCoordinator<Self>
-    
+
     public var source: Source {
         get {
             switch sourceValue {
@@ -28,29 +28,29 @@ public struct Sources<Source, Item>: UpdatableDataSource {
             performUpdate(to: newValue)
         }
     }
-    
+
     public let listDiffer: ListDiffer<Self>
     public let listUpdate: ListUpdate<Self>.Whole
     public var listOptions: ListOptions
-    
+
     public var listCoordinator: ListCoordinator<Self> { coordinator(with: coordinatorMaker(self)) }
-    
+
     public let coordinatorStorage = CoordinatorStorage<Self>()
-    
+
     public var wrappedValue: Source {
         get { source }
         nonmutating set { source = newValue }
     }
-    
+
     public var projectedValue: Sources<Source, Item> {
         get { self }
         set { self = newValue }
     }
-    
+
     public subscript<Value>(dynamicMember keyPath: KeyPath<Source, Value>) -> Value {
         source[keyPath: keyPath]
     }
-    
+
     public subscript<Value>(dynamicMember keyPath: WritableKeyPath<Source, Value>) -> Value {
         get { source[keyPath: keyPath] }
         nonmutating set { source[keyPath: keyPath] = newValue }

--- a/Sources/Utility/Associator.swift
+++ b/Sources/Utility/Associator.swift
@@ -13,7 +13,7 @@ class Associator {
         case retain
         case weak
         case copy
-        
+
         var policy: objc_AssociationPolicy {
             switch self {
             case .assign: return .OBJC_ASSOCIATION_ASSIGN
@@ -21,7 +21,7 @@ class Associator {
             case .copy: return .OBJC_ASSOCIATION_COPY
             }
         }
-        
+
         func set<AssociatedValue>(value: AssociatedValue?) -> Any? {
             if self == .weak {
                 weak var anyObject = value as AnyObject?
@@ -30,19 +30,19 @@ class Associator {
                 return value
             }
         }
-        
+
         fileprivate static func get<AssociatedValue>(from value: Any?) -> AssociatedValue? {
             value as? AssociatedValue ?? (value as? () -> AnyObject?)?() as? AssociatedValue
         }
     }
-    
+
     static func getValue<AssociatedValue>(
         key: UnsafeRawPointer,
         from object: AnyObject
     ) -> AssociatedValue? {
         Policy.get(from: objc_getAssociatedObject(object, key))
     }
-    
+
     static func getValue<AssociatedValue>(
         key: UnsafeRawPointer,
         from object: AnyObject,
@@ -55,7 +55,7 @@ class Associator {
             return value
         }()
     }
-    
+
     static func set<AssociatedValue>(
         value: AssociatedValue?,
         policy: Policy = .retain,

--- a/Sources/Utility/ChangeSet.swift
+++ b/Sources/Utility/ChangeSet.swift
@@ -10,7 +10,7 @@ import Foundation
 struct ChangeSets<Set: UpdateIndexCollection> {
     typealias Index = Set.Element
     typealias Indices = Set.Elements
-    
+
     var source = BatchUpdates.Source<Set>()
     var target = BatchUpdates.Target<Set>()
     var reloadDict = [Index: Index]()
@@ -20,31 +20,31 @@ extension ChangeSets {
     mutating func insert(_ index: Index) {
         target.add(\.inserts, index)
     }
-    
+
     mutating func insert(_ indices: Indices) {
         target.add(\.inserts, indices)
     }
-    
+
     mutating func delete(_ index: Index) {
         source.add(\.deletes, index)
     }
-    
+
     mutating func delete(_ indices: Indices) {
         source.add(\.deletes, indices)
     }
-    
+
     mutating func reload(_ index: Index, newIndex: Index) {
         source.add(\.reloads, index)
         target.add(\.reloads, newIndex)
         reloadDict[index] = newIndex
     }
-    
+
     mutating func reload(_ indices: Indices, newIndices: Indices) {
         source.add(\.reloads, indices)
         target.add(\.reloads, newIndices)
         zip(indices, newIndices).forEach { reloadDict[$0.0] = $0.1 }
     }
-    
+
     mutating func move(_ index: Index, to newIndex: Index) {
         source.move(index)
         target.move(index, to: newIndex)

--- a/Sources/Utility/Diff/CollectionDifference.swift
+++ b/Sources/Utility/Diff/CollectionDifference.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/3/17.
 //
 
+// swiftlint:disable all
+
 public struct CollectionDifference<ChangeElement> {
     /// A single change to a collection.
     public enum Change {

--- a/Sources/Utility/Diff/Differing.swift
+++ b/Sources/Utility/Diff/Differing.swift
@@ -5,6 +5,8 @@
 //  Created by Frain on 2019/3/17.
 //
 
+// swiftlint:disable all
+
 extension CollectionDifference {
     fileprivate func _fastEnumeratedApply(
         _ consume: (Change) throws -> Void

--- a/Sources/Utility/IndexPathSet.swift
+++ b/Sources/Utility/IndexPathSet.swift
@@ -10,52 +10,52 @@ import Foundation
 struct IndexPathSet: UpdateIndexCollection {
     typealias Element = IndexPath
     typealias Elements = [IndexPath]
-    
+
     static func insert(_ elements: Elements, by list: ListView) { list.insertItems(at: elements) }
     static func delete(_ elements: Elements, by list: ListView) { list.deleteItems(at: elements) }
     static func reload(_ elements: Elements, by list: ListView) { list.reloadItems(at: elements) }
     static func move(_ element: Mapping<IndexPath>, by list: ListView) {
         list.moveItem(at: element.source, to: element.target)
     }
-    
+
     var sections = IndexSet()
     var items = [Int: IndexSet]()
-    
+
     var isEmpty: Bool { items.isEmpty }
-    
+
     init() { }
-    
+
     init(_ element: IndexPath) {
         sections = .init(element.section)
         self[element.section] = .init(element.item)
     }
-    
+
     init(_ elements: [IndexPath]) {
         elements.forEach { self.add($0) }
     }
-    
+
     init(_ from: IndexPath, _ to: IndexPath) {
         sections.insert(from.section)
         self[from.section] = .init(from.item, to.item)
     }
-    
+
     subscript(key: Int) -> IndexSet {
         get { items[key] ?? .init() }
         set { items[key] = newValue }
     }
-    
+
     mutating func add(_ element: IndexPath) {
         sections.insert(element.section)
         self[element.section].insert(element.item)
     }
-    
+
     mutating func add(_ elements: [IndexPath]) {
         elements.forEach { self.add($0) }
     }
-    
+
     mutating func add(_ from: IndexPath, _ to: IndexPath) { add(.init(from, to)) }
     mutating func add(_ other: Self) { add(other.elements()) }
-    
+
     mutating func remove(_ indexPath: IndexPath) {
         self[indexPath.section].remove(indexPath.item)
         if self[indexPath.section].isEmpty {
@@ -63,7 +63,7 @@ struct IndexPathSet: UpdateIndexCollection {
             items[indexPath.section] = nil
         }
     }
-    
+
     func elements(_ offset: IndexPath? = nil) -> [IndexPath] {
         sections.flatMap { section -> [IndexPath] in
             items[section]!.map { .init(offset, section: section, item: $0) }

--- a/Sources/Utility/ListIndex.swift
+++ b/Sources/Utility/ListIndex.swift
@@ -12,22 +12,22 @@ protocol ListIndex: Hashable {
     static var isSection: Bool { get }
     var section: Int { get }
     var item: Int { get }
-    
+
     init(_ value: Self?, offset: Int)
     init(section: Int, item: Int)
     func offseted(_ offset: Int) -> Self
     func offseted(_ offset: Int, isSection: Bool) -> Self
     func offseted(_ index: Self, plus: Bool) -> Self
-    
+
     func add<Cache>(
         _ related: Self,
         from caches: inout ContiguousArray<ContiguousArray<Cache?>>,
         _ itemMoves: inout [IndexPath: Cache?],
         _ sectionMoves: inout [Int: ContiguousArray<Cache?>]
     )
-    
+
     func remove<Cache>(from caches: inout ContiguousArray<ContiguousArray<Cache?>>)
-    
+
     func insert<Cache>(
         to caches: inout ContiguousArray<ContiguousArray<Cache?>>,
         _ itemMoves: [IndexPath: Cache?],
@@ -43,41 +43,41 @@ extension ListIndex {
 extension IndexPath: ListIndex {
     static var zero: IndexPath { IndexPath(section: 0, item: 0) }
     static var isSection: Bool { false }
-    
+
     var section: Int {
         get { self[startIndex] }
         set { self[startIndex] = newValue }
     }
-    
+
     var item: Int {
         get { self[index(before: endIndex)] }
         set { self[index(before: endIndex)] = newValue }
     }
-    
+
     init(_ value: IndexPath?, offset: Int) {
         self = value?.offseted(offset) ?? .init(item: offset)
     }
-    
+
     init(_ value: IndexPath?, section: Int, item: Int) {
         self = value?.offseted(section, item) ?? .init(section: section, item: item)
     }
-    
+
     init(section: Int = 0, item: Int = 0) {
         self = [section, item]
     }
-    
+
     func offseted(_ offset: Int = 0) -> IndexPath {
         var indexPath = self
         indexPath.item = item + offset
         return indexPath
     }
-    
+
     func offseted(_ offset: Int, isSection: Bool) -> IndexPath {
         var indexPath = self
         isSection ? (indexPath.section += offset) : (indexPath.item += offset)
         return indexPath
     }
-    
+
     func offseted(_ section: Int, _ item: Int, plus: Bool = true) -> IndexPath {
         if section == 0, item == 0 { return self }
         var indexPath = self
@@ -85,11 +85,11 @@ extension IndexPath: ListIndex {
         indexPath.section = self.section + (plus ? section : -section)
         return indexPath
     }
-    
+
     func offseted(_ index: IndexPath, plus: Bool = true) -> IndexPath {
         offseted(index.section, index.item, plus: plus)
     }
-    
+
     func add<Cache>(
         _ related: Self,
         from caches: inout ContiguousArray<ContiguousArray<Cache?>>,
@@ -98,11 +98,11 @@ extension IndexPath: ListIndex {
     ) {
         itemMoves[self] = caches[related.section][related.item]
     }
-    
+
     func remove<Cache>(from caches: inout ContiguousArray<ContiguousArray<Cache?>>) {
         caches[section].remove(at: item)
     }
-    
+
     func insert<Cache>(
         to caches: inout ContiguousArray<ContiguousArray<Cache?>>,
         _ itemMoves: [IndexPath: Cache?],
@@ -120,17 +120,17 @@ extension IndexPath: ListIndex {
 
 extension Int: ListIndex {
     static var isSection: Bool { true }
-    
+
     var section: Int { self }
     var item: Int { 0 }
-    
+
     init(_ value: Int?, offset: Int) { self = (value ?? 0) + offset }
     init(section: Int = 0, item: Int = 0) { self = section }
-    
+
     func offseted(_ offset: Int) -> Int { self + offset }
     func offseted(_ offset: Int, isSection: Bool) -> Int { isSection ? self + offset : self }
     func offseted(_ index: Int, plus: Bool) -> Int { self + (plus ? index : -index) }
-    
+
     func add<Cache>(
         _ related: Self,
         from caches: inout ContiguousArray<ContiguousArray<Cache?>>,
@@ -139,11 +139,11 @@ extension Int: ListIndex {
     ) {
         sectionMoves[self] = caches[related]
     }
-    
+
     func remove<Cache>(from caches: inout ContiguousArray<ContiguousArray<Cache?>>) {
         caches.remove(at: self)
     }
-    
+
     func insert<Cache>(
         to caches: inout ContiguousArray<ContiguousArray<Cache?>>,
         _ itemMoves: [IndexPath: Cache?],

--- a/Sources/Utility/SourceType.swift
+++ b/Sources/Utility/SourceType.swift
@@ -9,7 +9,7 @@ enum SourceType {
     case section
     case sectionItems
     case items
-    
+
     var isSection: Bool { self == .section || self == .sectionItems }
     var isItems: Bool { self == .items || self == .sectionItems }
 }

--- a/Tests/ListKitTests/ListKitTests.swift
+++ b/Tests/ListKitTests/ListKitTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import ListKit
+import XCTest
 
 final class ListKitTests: XCTestCase {
     func testExample() {


### PR DESCRIPTION
## Description
This PR ingests SwiftLint by
1. disable rules for all code
    - force_cast: we use force cast since we know it could not be nil or it could expose the logic error as soon as possible.
    - nesting: nested type declarations are more succinct than plain one.
    - trailing_comma: we will always add a comma after element even there is only one element in the array as it will make the diff of future change more easy to read
2. configuring rules for all code
    - cyclomatic_complexity: the max of cyclomatic complexity is upgraded to 14.
    - file_length: the length thresholds for emitting warning/error are upgraded to 800/1500
    - identifier_name: the range of the number of characters for identifier name is configured to 2-40 and `_` is allowed.
    - line_length: the max length for a single line is upgraded to 250.
    - type_name: the range of the number of characters for type name is configured to 2-40 and `_` is allowed.
3. update code to conform other rules
    - delete redundant trailing new lines
    - add white space after `//`
    - sort import statements
    - ...
5. disable some rules for specific code
    - opening_brace
    - trailing_white_space
    - ...

This is a "huge" PR since it affects dozens of files, but most of the changes are made by the refactor tool or the autofix command, so in theory, it won't affect the actual logic and I also try to keep the changes as less as possible.

This is the first step to leverage SwiftLint to produce a more unified code style and conventions. We'll add a GitHub action to force guarantee the unification.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Alpensegler/.github//blob/master/CONTRIBUTING.md) guide
- [x] I added a very descriptive title to this pull request
- [x] I have follow the [guide](https://www.conventionalcommits.org/en/v1.0.0/) to write commit messages