### PR TITLE
chore: add workflow to validate pr

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,18 @@
+name: "Validate PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  validate-title:
+    name: Validate title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Since we are changing the merge policy to squash and use the PR title for the generated commit message by default, this PR add a workflow with the action https://github.com/amannn/action-semantic-pull-request to enforce title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Alpensegler/.github//blob/master/CONTRIBUTING.md) guide
- [x] I added a very descriptive title to this pull request
- [x] I have follow the [guide](https://www.conventionalcommits.org/en/v1.0.0/) to write commit messages