### PR TITLE
fix: reslove lint warnings

### DIFF
--- a/ListKit.xcodeproj/project.pbxproj
+++ b/ListKit.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		F8FD93942877197B00DFF7DA /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Sources/Coordinator/SourcesCoordinator.swift
+++ b/Sources/Coordinator/SourcesCoordinator.swift
@@ -92,7 +92,7 @@ where
     init(
         _ sourceBase: SourceBase,
         toSource: @escaping (SourceBase.Source) -> (Source),
-        fromSource:  @escaping (Source) -> SourceBase.Source
+        fromSource: @escaping (Source) -> SourceBase.Source
     ) {
         let source = sourceBase.source
         subsourceType = .fromSourceBase(toSource, fromSource)


### PR DESCRIPTION
## Description
This PR resolve warnings for lint:
1. Resolve a `colon` lint
2. Resolve a build [warning](https://github.com/realm/SwiftLint/issues/4015) for the lint build script introduced in Xcode